### PR TITLE
Fixing BUG #7 (v2): Presentation and Zoom buttons greyed out, if no document has been loaded.

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -450,6 +450,10 @@ ev_window_setup_action_sensitivity (EvWindow *ev_window)
 	ev_window_set_action_sensitive (ev_window, "ViewAutoscroll", has_pages && !(document->iswebdocument));
 	ev_window_set_action_sensitive (ev_window, "ViewInvertedColors", has_pages);
 	ev_window_set_action_sensitive (ev_window, "ViewExpandWindow", has_pages && !(document->iswebdocument));
+	ev_window_set_action_sensitive (ev_window, "ViewZoomIn", has_pages && !(document->iswebdocument));
+	ev_window_set_action_sensitive (ev_window, "ViewZoomOut", has_pages && !(document->iswebdocument));
+	ev_window_set_action_sensitive (ev_window, "ViewPresentation", has_pages && !(document->iswebdocument));
+
 
 	/* Bookmarks menu */
 	ev_window_set_action_sensitive (ev_window, "BookmarksAdd",
@@ -3897,6 +3901,8 @@ static void
 ev_window_update_fullscreen_action (EvWindow *window)
 {
 	GtkAction *action;
+	EvDocument *document = window->priv->document;
+	gboolean has_pages = FALSE;
 
 	action = gtk_action_group_get_action (window->priv->action_group, "ViewFullscreen");
 	g_signal_handlers_block_by_func
@@ -3905,6 +3911,14 @@ ev_window_update_fullscreen_action (EvWindow *window)
 				      ev_document_model_get_fullscreen (window->priv->model));
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_fullscreen), window);
+
+	/* Disable presentation start button, if no document has been loaded */
+	if (document) {
+		has_pages = ev_document_get_n_pages (document) > 0;
+	}
+	ev_window_set_action_sensitive (window,
+			"StartPresentation",
+			has_pages && !(document->iswebdocument));
 }
 
 static void


### PR DESCRIPTION
This patch makes zoomin/out and presentation buttons inactive in the menue,
the regular toolbar, and the fullscreen toolbar, if no document has been loaded yet.