### PR TITLE
Fix for bug #12: not saving changes to a dropdown in an embedded form

### DIFF
--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -2236,7 +2236,7 @@ ev_view_form_field_text_create_widget (EvView      *view,
 				g_free (txt);
 			}
 
-			g_signal_connect( buffer, "focus-out-event",
+			g_signal_connect (text, "focus-out-event",
 					  G_CALLBACK (ev_view_form_field_text_focus_out),
 					  view);
 			g_signal_connect (buffer, "changed",
@@ -2294,7 +2294,7 @@ ev_view_form_field_choice_changed (GtkWidget   *widget,
 {
 	EvFormFieldChoice *field_choice = EV_FORM_FIELD_CHOICE (field);
 	
-	if (gtk_combo_box_get_has_entry ( GTK_COMBO_BOX (widget))) {
+	if (GTK_IS_COMBO_BOX (widget)) {
 		gint item;
 		
 		item = gtk_combo_box_get_active (GTK_COMBO_BOX (widget));


### PR DESCRIPTION
Issue #12 is a regression from commit f8aec907364307470991b0b0d1b7b883c7397c57:
GTK_IS_COMBO_BOX is deprecated, use gtk_combo_box_get_has_entry

However, I just open this PR for discussion. Since GTK_IS_COMBO_BOX is deprecated, it is not the right way to go, but on the other hand it solves issue #12.

@infirit and others: What do you think? How can we use `gtk_combo_box_get_has_entry`, such that it solves this issue too?

**EDIT: I think GTK_IS_COMBO_BOX is not deprecated!**