### PR TITLE
Fixing bug17

### DIFF
--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -110,6 +110,8 @@ typedef struct _EvHeightToPageCache {
 struct _EvView {
 	GtkLayout layout;
 
+	/* Container */
+	GList *children;
 	EvDocument *document;
 
 	/* Find */


### PR DESCRIPTION
Solving an issue where form fields are misplaced and have a wrong dimension.

This merge is based on the following commits:

1)
commit https://git.gnome.org/browse/evince/commit/?id=de237e03970b02ee0823c79a3917d3d45aba999b
Author: Carlos Garcia Campos <carlosgc@gnome.org>
Date:   Mon Feb 21 20:16:44 2011 +0100

    libview: Make EvView inherit from GtkContainer instead of GtkFixed

    It makes handling child widgets easier. Based on patch by José aliste,
    see bug #573748.

2)
commit https://git.gnome.org/browse/evince/commit/?id=c9c080f02545ecc06fb29119253e39b231247e4b
Author: Carlos Garcia Campos <carlosgc@gnome.org>
Date:   Sat Apr 13 15:21:01 2013 +0200

    libview: Take into account the page border when transforming to view coordinates

    And use the same conversion from double to int used in other places to
    make sure the result is consistent. This fixes the wrong positioning of
    several elements like result highlights, annotation focus, form fields,
    etc.