### PR TITLE
Fix page shadow

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -163,7 +163,21 @@ ev_document_misc_paint_one_page (cairo_t      *cr,
 
 	gdk_cairo_set_source_color (cr, highlight ? &style->text[state] : &style->dark[state]);
 #endif
-	gdk_cairo_rectangle (cr, area);
+	cairo_rectangle (cr,
+			 area->x,
+			 area->y,
+			 area->width - border->right + border->left,
+			 area->height - border->bottom + border->top);
+	cairo_rectangle (cr,
+			 area->x + area->width - border->right,
+			 area->y + border->right - border->left,
+			 border->right,
+			 area->height - border->right + border->left);
+	cairo_rectangle (cr,
+			 area->x + border->bottom - border->top,
+			 area->y + area->height - border->bottom,
+			 area->width - border->bottom + border->top,
+			 border->bottom);
 	cairo_fill (cr);
 
 	if (inverted_colors)
@@ -175,25 +189,6 @@ ev_document_misc_paint_one_page (cairo_t      *cr,
 			 area->y + border->top,
 			 area->width - (border->left + border->right),
 			 area->height - (border->top + border->bottom));
-	cairo_fill (cr);
-
-#if GTK_CHECK_VERSION (3, 0, 0)
-	gdk_cairo_set_source_rgba (cr, &bg);
-#else
-	gdk_cairo_set_source_color (cr, &style->mid[state]);
-#endif
-	cairo_rectangle (cr,
-			 area->x,
-			 area->y + area->height - (border->bottom - border->top),
-			 border->bottom - border->top,
-			 border->bottom - border->top);
-	cairo_fill (cr);
-
-	cairo_rectangle (cr,
-			 area->x + area->width - (border->right - border->left),
-			 area->y,
-			 border->right - border->left,
-			 border->right - border->left);
 	cairo_fill (cr);
 }
 

--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -144,17 +144,11 @@ ev_document_misc_paint_one_page (cairo_t      *cr,
 	GtkStyleContext *context = gtk_widget_get_style_context (widget);
 	GtkStateFlags state = gtk_widget_get_state_flags (widget);
         GdkRGBA fg, bg, shade_bg;
-        GtkSymbolicColor *c1, *c2;
 
         gtk_style_context_get_background_color (context, state, &bg);
         gtk_style_context_get_color (context, state, &fg);
-
-        // FIXME: should we cache the shade_bg?
-        c1 = gtk_symbolic_color_new_literal (&bg);
-        c2 = gtk_symbolic_color_new_shade (c1, 0.7);
-        gtk_symbolic_color_resolve (c2, NULL, &shade_bg);
-        gtk_symbolic_color_unref (c1);
-        gtk_symbolic_color_unref (c2);
+        gtk_style_context_get_color (context, state, &shade_bg);
+        shade_bg.alpha *= 0.5;
 
 	gdk_cairo_set_source_rgba (cr, highlight ? &fg : &shade_bg);
 #else


### PR DESCRIPTION
The page shadow is currently rendered incorrectly in the top right and bottom left corners and doesn't look like a shadow.
![bug](https://cloud.githubusercontent.com/assets/1450212/17954520/875b8736-6a49-11e6-992d-fde798f5bd0d.png)

This pull request fixes this by changing how the page border and shadow are drawn.
![fixed](https://cloud.githubusercontent.com/assets/1450212/17954547/add97e7c-6a49-11e6-8b18-b55de0c9a3b9.png)

It also fixes the rendering of the page shadow for inactive pages.

Here's a possibly relevant Evince commit: https://github.com/GNOME/evince/commit/dbc67b85fa737fa9a66c4bc7b4c30e82be9c8543