### PR TITLE
Case sensitive search within PDF files, fixes issue 47

### DIFF
--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -1523,13 +1523,17 @@ pdf_document_find_find_text (EvDocumentFind *document_find,
 	PopplerPage *poppler_page;
 	gdouble height;
 	GList *retval = NULL;
+	PopplerFindFlags options = POPPLER_FIND_DEFAULT;
 
 	g_return_val_if_fail (POPPLER_IS_PAGE (page->backend_page), NULL);
 	g_return_val_if_fail (text != NULL, NULL);
 
 	poppler_page = POPPLER_PAGE (page->backend_page);
 	
-	matches = poppler_page_find_text (poppler_page, text);
+	if (case_sensitive)
+		options = POPPLER_FIND_CASE_SENSITIVE;
+
+	matches = poppler_page_find_text_with_options (poppler_page, text, options);
 	if (!matches)
 		return NULL;
 

--- a/configure.ac
+++ b/configure.ac
@@ -381,7 +381,7 @@ AC_ARG_ENABLE([pdf],
   [enable_pdf=yes])
 
 if test "x$enable_pdf" = "xyes"; then
-    POPPLER_REQUIRED=0.18.0
+    POPPLER_REQUIRED=0.22.0
     PKG_CHECK_MODULES(POPPLER, poppler-glib >= $POPPLER_REQUIRED libxml-2.0 >= $LIBXML_REQUIRED,enable_pdf=yes,enable_pdf=no)
 
     if test "x$enable_pdf" = "xyes"; then


### PR DESCRIPTION
Case-sensitive search was not possible until now, although the search bar showed an option for it.
Fixes #47 