### PR TITLE
Comics: Support application/vnd.comicbook+zip MIME type and open files with special chars

### DIFF
--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -959,7 +959,7 @@ extract_argv (EvDocument *document, gint page)
                 return NULL;
 
 	if (comics_document->regex_arg) {
-		quoted_archive = comics_regex_quote (comics_document->archive);
+		quoted_archive = g_shell_quote (comics_document->archive);
 		quoted_filename =
 			comics_regex_quote (comics_document->page_names->pdata[page]);
 	} else {

--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -306,8 +306,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 	/* FIXME, use proper cbr/cbz mime types once they're
 	 * included in shared-mime-info */
 	
-	if (!strcmp (mime_type, "application/x-cbr") ||
-	    !strcmp (mime_type, "application/x-rar")) {
+	if (g_content_type_is_a (mime_type, "application/x-cbr") ||
+	    g_content_type_is_a (mime_type, "application/x-rar")) {
 	        /* The RARLAB provides a no-charge proprietary (freeware) 
 	        * decompress-only client for Linux called unrar. Another 
 		* option is a GPLv2-licensed command-line tool developed by 
@@ -362,8 +362,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 			return TRUE;
 		}
 
-	} else if (!strcmp (mime_type, "application/x-cbz") ||
-		   !strcmp (mime_type, "application/zip")) {
+	} else if (g_content_type_is_a (mime_type, "application/x-cbz") ||
+		   g_content_type_is_a (mime_type, "application/zip")) {
 		/* InfoZIP's unzip program */
 		comics_document->selected_command = 
 				g_find_program_in_path ("unzip");
@@ -381,8 +381,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 			return TRUE;
 		}
 
-	} else if (!strcmp (mime_type, "application/x-cb7") ||
-		   !strcmp (mime_type, "application/x-7z-compressed")) {
+	} else if (g_content_type_is_a (mime_type, "application/x-cb7") ||
+		   g_content_type_is_a (mime_type, "application/x-7z-compressed")) {
 		/* 7zr, 7za and 7z are the commands from the p7zip project able 
 		 * to decompress .7z files */ 
 		comics_document->selected_command =
@@ -409,8 +409,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 			comics_document->command_usage = TAR;
 			return TRUE;
 		}
-	} else if (!strcmp (mime_type, "application/x-cbt") ||
-		   !strcmp (mime_type, "application/x-tar")) {
+	} else if (g_content_type_is_a (mime_type, "application/x-cbt") ||
+		   g_content_type_is_a (mime_type, "application/x-tar")) {
 		/* tar utility (Tape ARchive) */
 		comics_document->selected_command =
 				g_find_program_in_path ("tar");

--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -385,30 +385,30 @@ comics_check_decompress_command	(gchar          *mime_type,
 		   !strcmp (mime_type, "application/x-7z-compressed")) {
 		/* 7zr, 7za and 7z are the commands from the p7zip project able 
 		 * to decompress .7z files */ 
-			comics_document->selected_command = 
-				g_find_program_in_path ("7zr");
-			if (comics_document->selected_command) {
-				comics_document->command_usage = P7ZIP;
-				return TRUE;
-			}
-			comics_document->selected_command = 
-				g_find_program_in_path ("7za");
-			if (comics_document->selected_command) {
-				comics_document->command_usage = P7ZIP;
-				return TRUE;
-			}
-			comics_document->selected_command = 
-				g_find_program_in_path ("7z");
-			if (comics_document->selected_command) {
-				comics_document->command_usage = P7ZIP;
-				return TRUE;
-			}
-			comics_document->selected_command =
-					g_find_program_in_path ("bsdtar");
-			if (comics_document->selected_command) {
-				comics_document->command_usage = TAR;
-				return TRUE;
-			}
+		comics_document->selected_command =
+			g_find_program_in_path ("7zr");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = P7ZIP;
+			return TRUE;
+		}
+		comics_document->selected_command =
+			g_find_program_in_path ("7za");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = P7ZIP;
+			return TRUE;
+		}
+		comics_document->selected_command =
+			g_find_program_in_path ("7z");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = P7ZIP;
+			return TRUE;
+		}
+		comics_document->selected_command =
+				g_find_program_in_path ("bsdtar");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = TAR;
+			return TRUE;
+		}
 	} else if (!strcmp (mime_type, "application/x-cbt") ||
 		   !strcmp (mime_type, "application/x-tar")) {
 		/* tar utility (Tape ARchive) */

--- a/backend/comics/comicsdocument.xreader-backend.in
+++ b/backend/comics/comicsdocument.xreader-backend.in
@@ -1,4 +1,4 @@
 [Xreader Backend]
 Module=comicsdocument
 _TypeDescription=Comic Books
-MimeType=application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;
+MimeType=application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;

--- a/configure.ac
+++ b/configure.ac
@@ -629,7 +629,7 @@ if test "x$enable_tiff" = "xyes"; then
     XREADER_MIME_TYPES="${XREADER_MIME_TYPES}image/tiff;"
 fi
 if test "x$enable_comics" = "xyes"; then
-    XREADER_MIME_TYPES="${XREADER_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;"
+    XREADER_MIME_TYPES="${XREADER_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;"
 fi
 if test "x$enable_pixbuf" = "xyes"; then
     XREADER_MIME_TYPES="${XREADER_MIME_TYPES}image/*;"


### PR DESCRIPTION
PR for 4 backports that all belong to the comics backend.
Does two things:

1) Adds support for application/vnd.comicbook+zip MIME type
2) Fixes open files with special chars in path