### PR TITLE
ATRIL BACKPORTS: add some missing contextual information for translators

### DIFF
--- a/libview/ev-print-operation.c
+++ b/libview/ev-print-operation.c
@@ -1304,7 +1304,8 @@ ev_print_operation_export_run (EvPrintOperation *op,
 
 	export->parent_window = parent;
 	export->error = NULL;
-	
+
+	/* translators: Title of the print dialog */
 	dialog = gtk_print_unix_dialog_new (_("Print"), parent);
 	gtk_window_set_modal (GTK_WINDOW (dialog), TRUE);
 	
@@ -1889,6 +1890,7 @@ ev_print_operation_print_create_custom_widget (EvPrintOperationPrint *print,
 	gtk_widget_show (label);
 
 	print->scale_combo = gtk_combo_box_text_new ();
+	/* translators: Value for 'Page Scaling:' to not scale the document pages on printing */
 	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (print->scale_combo), _("None"));
 	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (print->scale_combo), _("Shrink to Printable Area"));
 	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (print->scale_combo), _("Fit to Printable Area"));

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -296,6 +296,7 @@ static const GtkActionEntry action_entries[] = {
           N_("Shrink the document"),
           G_CALLBACK (ev_previewer_window_zoom_out) },
 #if GTKUNIXPRINT_ENABLED
+	/* translators: Print document currently shown in the Print Preview window */
 	{ "PreviewPrint", GTK_STOCK_PRINT, N_("Print"), NULL,
 	  N_("Print this document"),
 	  G_CALLBACK (ev_previewer_window_print) }

--- a/properties-caja/ev-properties-view.c
+++ b/properties-caja/ev-properties-view.c
@@ -197,6 +197,11 @@ set_property (EvPropertiesView *properties,
 	}
 
 	if (text == NULL || text[0] == '\000') {
+		/* translators: This is used when a document property does
+		   not have a value.  Examples:
+		   Author: None
+		   Keywords: None
+		*/
 		markup = g_markup_printf_escaped ("<i>%s</i>", _("None"));
 		gtk_label_set_markup (GTK_LABEL (label), markup);
 		g_free (markup);


### PR DESCRIPTION
commit 921ee4b7690bd476d97b816f93339eda213342f0
Author: monsta <monsta@inbox.ru>
Date:   Thu Jul 28 15:14:29 2016 +0300

    add some missing contextual information for translators

    ported from:
    https://git.gnome.org/browse/evince/commit/?id=544d9b4a73011c1e5a7b1d37b05a94f761d0dc03