### PR TITLE
ATRIL BACKPORTS: thumbnailer: skip epub files

### DIFF
--- a/thumbnailer/Makefile.am
+++ b/thumbnailer/Makefile.am
@@ -33,6 +33,7 @@ thumbnailer_DATA = $(thumbnailer_in_files:.thumbnailer.in=.thumbnailer)
 xreader.thumbnailer: $(thumbnailer_in_files)
 	$(AM_V_GEN)sed \
 		-e "s|\@XREADER_MIME_TYPES\@|$(XREADER_MIME_TYPES)|" \
+		-e "s|application/epub+zip;||" \
 		$< > $@
 
 EXTRA_DIST =         	\


### PR DESCRIPTION
commit b479e541d113881b10ef7c0641688d62600c79a9
Author: monsta <monsta@inbox.ru>
Date:   Mon Oct 31 11:49:47 2016 +0300

    thumbnailer: skip epub files

    temporary workaround for stupid segfaults - until we implement
    proper thumbnailing in epub backend