### PR TITLE
BUILD: --disable-caja and --disable-nemo are no longer ignored

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,12 +6,16 @@ SUBDIRS =       \
     libdocument \
     backend     \
     libview     \
-    libmisc     \
-    properties-caja  \
-    properties-nemo  \
-    shell       \
-    po          \
-    help
+    libmisc
+
+
+if ENABLE_CAJA
+    SUBDIRS += properties-caja
+endif
+
+if ENABLE_NEMO
+    SUBDIRS += properties-nemo
+endif
 
 if ENABLE_TESTS
     SUBDIRS += test
@@ -24,6 +28,11 @@ endif
 if ENABLE_PREVIEWER
     SUBDIRS += previewer
 endif
+
+# dpkg-buildpackage: Building shell, po and help is dependent of properties-nemo
+# and properties-caja, which must be build before.
+SUBDIRS += shell po help
+
 
 NULL =
 
@@ -39,7 +48,7 @@ header_DATA = \
     xreader-view.h \
     $(NULL)
 
-# Applications 
+# Applications
 
 intltool_extra = intltool-extract.in intltool-merge.in intltool-update.in
 

--- a/debian/rules
+++ b/debian/rules
@@ -36,6 +36,8 @@ override_dh_auto_configure:
 		--enable-t1lib \
 		--enable-pixbuf \
 		--enable-comics \
+		--enable-caja \
+		--enable-nemo \
 		--enable-introspection \
 		--disable-static \
 		$(DEB_XREADER_FLAGS)

--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -102,13 +102,20 @@ xreader_LDADD=										\
 	$(top_builddir)/cut-n-paste/totem-screensaver/libtotemscrsaver.la		\
 	$(top_builddir)/cut-n-paste/gimpcellrenderertoggle/libgimpcellrenderertoggle.la	\
 	$(top_builddir)/cut-n-paste/smclient/libsmclient.la				\
-	$(top_builddir)/properties-caja/libevproperties.la					\
-	$(top_builddir)/properties-nemo/libevproperties.la					\
 	$(top_builddir)/libdocument/libxreaderdocument.la					\
 	$(top_builddir)/libview/libxreaderview.la						\
 	$(top_builddir)/libmisc/libevmisc.la						\
 	$(SHELL_LIBS)									\
 	$(MATE_DESKTOP_LIBS)
+
+if ENABLE_CAJA
+    xreader_LDADD+=$(top_builddir)/properties-caja/libevproperties.la
+endif
+
+if ENABLE_NEMO
+    xreader_LDADD+=$(top_builddir)/properties-nemo/libevproperties.la
+endif
+
 
 BUILT_SOURCES = ev-marshal.h ev-marshal.c
 


### PR DESCRIPTION
Currently these options still enter the directories of properties-nemo/caja and
execute their makefiles. With this patch these directories will not be entered
anymore if --disable-caja or --disable-nemo are set.