### PR TITLE
configure.ac: Fix a build break

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -614,7 +614,7 @@ if test "x$enable_dvi" = "xyes"; then
     XREADER_MIME_TYPES="${XREADER_MIME_TYPES}application/x-dvi;application/x-bzdvi;application/x-gzdvi;"
 fi
 if test "x$enable_djvu" = "xyes"; then
-    XREADER_MIME_TYPES="${XREADER_MIME_TYPES}image/vnd.djvu;image/vnd.djvu+multipage;""
+    XREADER_MIME_TYPES="${XREADER_MIME_TYPES}image/vnd.djvu;image/vnd.djvu+multipage;"
 fi
 if test "x$enable_tiff" = "xyes"; then
     XREADER_MIME_TYPES="${XREADER_MIME_TYPES}image/tiff;"


### PR DESCRIPTION
https://github.com/linuxmint/xreader/commit/068f2103ff74b3ea9698a7a01af633c5c502b48f
broke the build by adding in a stray quotation mark. Remove it.