### PR TITLE
Add a new EvToolbar

### DIFF
--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -70,6 +70,8 @@ xreader_SOURCES=				\
 	ev-properties-view.h		\
 	ev-open-recent-action.c		\
 	ev-open-recent-action.h		\
+	ev-toolbar.c 		\
+	ev-toolbar.h 		\
 	ev-utils.c			\
 	ev-utils.h			\
 	ev-window.c			\

--- a/shell/ev-toolbar.c
+++ b/shell/ev-toolbar.c
@@ -1,0 +1,178 @@
+/* ev-toolbar.c
+ *  this file is part of xreader, a document viewer
+ */
+
+#include "config.h"
+
+#include "ev-toolbar.h"
+
+enum
+{
+    PROP_0,
+    PROP_WINDOW
+};
+
+struct _EvToolbarPrivate
+{
+    GtkStyleContext *style_context;
+
+    GtkWidget *fullscreen_group;
+
+    EvWindow *window;
+};
+
+G_DEFINE_TYPE (EvToolbar, ev_toolbar, GTK_TYPE_TOOLBAR)
+
+static void
+ev_toolbar_set_property (GObject      *object,
+                         guint         prop_id,
+                         const GValue *value,
+                         GParamSpec   *pspec)
+{
+    EvToolbar *ev_toolbar = EV_TOOLBAR (object);
+
+    switch (prop_id)
+    {
+        case PROP_WINDOW:
+            ev_toolbar->priv->window = g_value_get_object (value);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static GtkWidget *
+create_button (GtkAction *action)
+{
+    GtkWidget *button;
+    GtkWidget *image;
+    GtkWidget *label;
+    GtkWidget *box;
+
+    button = gtk_button_new ();
+    image = gtk_image_new_from_icon_name (gtk_action_get_icon_name (action), GTK_ICON_SIZE_MENU);
+    label = gtk_label_new (gtk_action_get_short_label (action));
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 4);
+
+    gtk_container_add (GTK_CONTAINER (button), box);
+    gtk_box_pack_start (GTK_BOX (box), image, FALSE, FALSE, 0);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+    gtk_style_context_add_class (gtk_widget_get_style_context (button), "flat");
+    gtk_activatable_set_related_action (GTK_ACTIVATABLE (button), action);
+    gtk_widget_set_tooltip_text (button, gtk_action_get_tooltip (action));
+
+    return button;
+}
+
+static void
+ev_toolbar_constructed (GObject *object)
+{
+    EvToolbar *ev_toolbar = EV_TOOLBAR (object);
+    GtkActionGroup *action_group;
+    GtkAction *action;
+    GtkToolItem *tool_item;
+    GtkWidget *box;
+    GtkWidget *button;
+
+    G_OBJECT_CLASS (ev_toolbar_parent_class)->constructed (object);
+
+    ev_toolbar->priv->style_context = gtk_widget_get_style_context (GTK_WIDGET (ev_toolbar));
+    gtk_style_context_add_class (ev_toolbar->priv->style_context, "primary-toolbar");
+
+    action_group = ev_window_get_main_action_group (ev_toolbar->priv->window);
+
+    tool_item = gtk_tool_item_new ();
+    gtk_toolbar_insert (GTK_TOOLBAR (ev_toolbar), tool_item, 0);
+
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_container_add (GTK_CONTAINER (tool_item), box);
+
+    action = gtk_action_group_get_action (action_group, "GoPreviousPage");
+    button = create_button (action);
+    gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
+
+    action = gtk_action_group_get_action (action_group, "GoNextPage");
+    button = create_button (action);
+    gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
+
+    gtk_widget_show_all (GTK_WIDGET (tool_item));
+
+    action = gtk_action_group_get_action (action_group, "PageSelector");
+    tool_item = GTK_TOOL_ITEM (gtk_action_create_tool_item (action));
+    gtk_container_add (GTK_CONTAINER (ev_toolbar), GTK_WIDGET (tool_item));
+    gtk_widget_show (GTK_WIDGET (tool_item));
+
+    action = gtk_action_group_get_action (action_group, "ViewZoom");
+    tool_item = GTK_TOOL_ITEM (gtk_action_create_tool_item (action));
+    gtk_container_add (GTK_CONTAINER (ev_toolbar), GTK_WIDGET (tool_item));
+    gtk_widget_show (GTK_WIDGET (tool_item));
+
+    /* Setup the buttons we only want to show when fullscreened */
+    tool_item = gtk_tool_item_new ();
+    gtk_tool_item_set_expand (tool_item, TRUE);
+    gtk_container_add (GTK_CONTAINER (ev_toolbar), GTK_WIDGET (tool_item));
+    gtk_widget_show (GTK_WIDGET (tool_item));
+    ev_toolbar->priv->fullscreen_group = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_container_add (GTK_CONTAINER (tool_item), ev_toolbar->priv->fullscreen_group);
+
+    action = gtk_action_group_get_action (action_group, "LeaveFullscreen");
+    button = create_button (action);
+    gtk_box_pack_end (GTK_BOX (ev_toolbar->priv->fullscreen_group), button, FALSE, FALSE, 0);
+
+    action = gtk_action_group_get_action (action_group, "StartPresentation");
+    button = create_button (action);
+    gtk_box_pack_end (GTK_BOX (ev_toolbar->priv->fullscreen_group), button, FALSE, FALSE, 0);
+}
+
+static void
+ev_toolbar_class_init (EvToolbarClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->set_property = ev_toolbar_set_property;
+    object_class->constructed = ev_toolbar_constructed;
+
+    g_object_class_install_property (object_class,
+                                     PROP_WINDOW,
+                                     g_param_spec_object ("window",
+                                                          "Window",
+                                                          "The parent xreader window",
+                                                          EV_TYPE_WINDOW,
+                                                          G_PARAM_WRITABLE |
+                                                          G_PARAM_CONSTRUCT_ONLY |
+                                                          G_PARAM_STATIC_STRINGS));
+
+    g_type_class_add_private (object_class, sizeof (EvToolbarPrivate));
+}
+
+static void
+ev_toolbar_init (EvToolbar *ev_toolbar)
+{
+    ev_toolbar->priv = G_TYPE_INSTANCE_GET_PRIVATE (ev_toolbar, EV_TYPE_TOOLBAR, EvToolbarPrivate);
+}
+
+GtkWidget *
+ev_toolbar_new (EvWindow *window)
+{
+    g_return_val_if_fail (EV_IS_WINDOW (window), NULL);
+
+    return GTK_WIDGET (g_object_new (EV_TYPE_TOOLBAR, "window", window, NULL));
+}
+
+void
+ev_toolbar_set_style (EvToolbar *ev_toolbar,
+                      gboolean   is_fullscreen)
+{
+    g_return_if_fail (EV_IS_TOOLBAR (ev_toolbar));
+
+    if (is_fullscreen && gtk_style_context_has_class (ev_toolbar->priv->style_context, "primary-toolbar"))
+    {
+        gtk_style_context_remove_class (ev_toolbar->priv->style_context, "primary-toolbar");
+        gtk_widget_show_all (ev_toolbar->priv->fullscreen_group);
+    }
+    else if (!is_fullscreen && !gtk_style_context_has_class (ev_toolbar->priv->style_context, "primary-toolbar"))
+    {
+        gtk_style_context_add_class (ev_toolbar->priv->style_context, "primary-toolbar");
+        gtk_widget_hide (ev_toolbar->priv->fullscreen_group);
+    }
+}

--- a/shell/ev-toolbar.h
+++ b/shell/ev-toolbar.h
@@ -1,0 +1,44 @@
+/* ev-toolbar.h
+ *  this file is part of xreader, a document viewer
+ */
+
+#ifndef __EV_TOOLBAR_H__
+#define __EV_TOOLBAR_H__
+
+#include <gtk/gtk.h>
+#include "ev-window.h"
+
+G_BEGIN_DECLS
+
+#define EV_TYPE_TOOLBAR            (ev_toolbar_get_type())
+#define EV_TOOLBAR(object)         (G_TYPE_CHECK_INSTANCE_CAST((object), EV_TYPE_TOOLBAR, EvToolbar))
+#define EV_IS_TOOLBAR(object)      (G_TYPE_CHECK_INSTANCE_TYPE((object), EV_TYPE_TOOLBAR))
+#define EV_TOOLBAR_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), EV_TYPE_TOOLBAR, EvToolbarClass))
+#define EV_IS_TOOLBAR_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), EV_TYPE_TOOLBAR))
+#define EV_TOOLBAR_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj), EV_TYPE_TOOLBAR, EvToolbarClass))
+
+typedef struct _EvToolbar        EvToolbar;
+typedef struct _EvToolbarClass   EvToolbarClass;
+typedef struct _EvToolbarPrivate EvToolbarPrivate;
+
+struct _EvToolbar
+{
+    GtkToolbar parent_object;
+
+    EvToolbarPrivate *priv;
+};
+
+struct _EvToolbarClass
+{
+        GtkToolbarClass parent_class;
+};
+
+GType ev_toolbar_get_type (void);
+GtkWidget *ev_toolbar_new (EvWindow *window);
+
+void ev_toolbar_set_style (EvToolbar *ev_toolbar,
+                           gboolean   is_fullscreen);
+
+G_END_DECLS
+
+#endif /* __EV_TOOLBAR_H__ */

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -627,14 +627,7 @@ update_chrome_visibility (EvWindow *window)
 	set_widget_visibility (priv->sidebar, sidebar);
 	gtk_revealer_set_reveal_child (GTK_REVEALER (priv->toolbar_revealer), toolbar);
 
-	if (fullscreen_toolbar)
-	{
-		ev_toolbar_set_style (priv->toolbar, TRUE);
-	}
-	else
-	{
-		ev_toolbar_set_style (priv->toolbar, FALSE);
-	}
+	ev_toolbar_set_style (priv->toolbar, fullscreen_toolbar);
 }
 
 static void

--- a/shell/ev-window.h
+++ b/shell/ev-window.h
@@ -87,6 +87,8 @@ void		ev_window_print_range   (EvWindow       *ev_window,
 					 int		 last_page);
 const gchar *	ev_window_get_dbus_object_path (EvWindow *ev_window);
 
+GtkActionGroup *ev_window_get_main_action_group (EvWindow *window);
+
 
 G_END_DECLS
 


### PR DESCRIPTION
Ditch using the two separate toolbars for fullscreen vs. normal. Just use a
single toolbar and update the style based on the window state. This also fixes
an issue where the page selector widget in the toolbar doesn't update
properly when going to fullscreen.