### PR TITLE
sidebar-layers: Make it actually usable

### DIFF
--- a/cut-n-paste/gimpcellrenderertoggle/gimpcellrenderertoggle.c
+++ b/cut-n-paste/gimpcellrenderertoggle/gimpcellrenderertoggle.c
@@ -356,6 +356,7 @@ gimp_cell_renderer_toggle_render (GtkCellRenderer      *cell,
       gdk_rectangle_intersect (&clip_rect, cell_area, &draw_rect))
     {
       cairo_save (cr);
+      gtk_style_context_save (context);
       gdk_cairo_rectangle (cr, &draw_rect);
       cairo_clip (cr);
       gtk_render_frame (context, //gtk_widget_get_style_context (widget),

--- a/shell/ev-sidebar-layers.c
+++ b/shell/ev-sidebar-layers.c
@@ -282,13 +282,11 @@ ev_sidebar_layers_init (EvSidebarLayers *ev_layers)
 	
 	ev_layers->priv = EV_SIDEBAR_LAYERS_GET_PRIVATE (ev_layers);
 
-	gtk_orientable_set_orientation (GTK_ORIENTABLE (ev_layers), GTK_ORIENTATION_VERTICAL);
 	swindow = gtk_scrolled_window_new (NULL, NULL);
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (swindow),
 					GTK_POLICY_NEVER,
 					GTK_POLICY_AUTOMATIC);
-	gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (swindow),
-					     GTK_SHADOW_IN);
+
 	/* Data Model */
 	model = ev_sidebar_layers_create_loading_model ();
 
@@ -300,7 +298,7 @@ ev_sidebar_layers_init (EvSidebarLayers *ev_layers)
 	gtk_container_add (GTK_CONTAINER (swindow),
 			   GTK_WIDGET (ev_layers->priv->tree_view));
 
-	gtk_container_add (GTK_CONTAINER (ev_layers), swindow);
+	gtk_box_pack_start (GTK_BOX (ev_layers), swindow, TRUE, TRUE, 0);
 	gtk_widget_show_all (GTK_WIDGET (ev_layers));
 }
 
@@ -329,7 +327,9 @@ ev_sidebar_layers_class_init (EvSidebarLayersClass *ev_layers_class)
 GtkWidget *
 ev_sidebar_layers_new (void)
 {
-	return GTK_WIDGET (g_object_new (EV_TYPE_SIDEBAR_LAYERS, NULL));
+	return GTK_WIDGET (g_object_new (EV_TYPE_SIDEBAR_LAYERS,
+                                     "orientation", GTK_ORIENTATION_VERTICAL,
+                                     NULL));
 }
 
 static void


### PR DESCRIPTION
Expand the scrolled window so that you can actually see the content of the
widget. This also turned up a missing gtk_style_context_save () in
gimpcellrenderertoggle.c so fix that as well.