### PR TITLE
ev-view: Properly declare a function

### DIFF
--- a/libview/ev-view.h
+++ b/libview/ev-view.h
@@ -67,6 +67,8 @@ gboolean	ev_view_can_zoom_in       (EvView         *view);
 void		ev_view_zoom_in		  (EvView         *view);
 gboolean        ev_view_can_zoom_out      (EvView         *view);
 void		ev_view_zoom_out	  (EvView         *view);
+void        ev_view_zoom (EvView  *view,
+						  gdouble  factor);
 
 /* Find */
 void            ev_view_find_next                 (EvView         *view);


### PR DESCRIPTION
We need to declare ev_view_zoom() before we use it.