### PR TITLE
 ATRIL BACKPORTS: PART 2 OF "move to GTK+3 (>= 3.14), drop GTK+2 code…

### DIFF
--- a/help/reference/shell/xreader-sections.txt
+++ b/help/reference/shell/xreader-sections.txt
@@ -336,8 +336,6 @@ egg_find_bar_set_search_string
 egg_find_bar_get_search_string
 egg_find_bar_set_case_sensitive
 egg_find_bar_get_case_sensitive
-egg_find_bar_get_all_matches_color
-egg_find_bar_get_current_match_color
 egg_find_bar_set_status_text
 <SUBSECTION Standard>
 EGG_FIND_BAR

--- a/libdocument/Makefile.am
+++ b/libdocument/Makefile.am
@@ -160,9 +160,9 @@ XreaderDocument-$(EV_API_VERSION).gir: libxreaderdocument.la Makefile $(INST_H_F
 	--nsversion=$(EV_API_VERSION) \
 	--include=GLib-2.0 \
 	--include=Gio-2.0 \
-	--include=Gdk-$(GTK_API_VERSION) \
+	--include=Gdk-3.0 \
 	--include=GdkPixbuf-2.0 \
-	--include=Gtk-$(GTK_API_VERSION) \
+	--include=Gtk-3.0 \
 	--library=xreaderdocument \
 	--libtool="$(LIBTOOL)" \
 	--output $@ \

--- a/libdocument/ev-attachment.c
+++ b/libdocument/ev-attachment.c
@@ -20,7 +20,7 @@
 #include <config.h>
 #include <glib/gi18n-lib.h>
 #include <glib/gstdio.h>
-#include <gtk/gtk.h>
+#include <gdk/gdk.h>
 #include "ev-file-helpers.h"
 #include "ev-attachment.h"
 

--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -140,23 +140,16 @@ ev_document_misc_paint_one_page (cairo_t      *cr,
 				 gboolean      highlight,
 				 gboolean      inverted_colors)
 {
-#if GTK_CHECK_VERSION (3, 0, 0)
 	GtkStyleContext *context = gtk_widget_get_style_context (widget);
 	GtkStateFlags state = gtk_widget_get_state_flags (widget);
-        GdkRGBA fg, bg, shade_bg;
+    GdkRGBA fg, bg, shade_bg;
 
-        gtk_style_context_get_background_color (context, state, &bg);
-        gtk_style_context_get_color (context, state, &fg);
-        gtk_style_context_get_color (context, state, &shade_bg);
-        shade_bg.alpha *= 0.5;
+    gtk_style_context_get_background_color (context, state, &bg);
+    gtk_style_context_get_color (context, state, &fg);
+    gtk_style_context_get_color (context, state, &shade_bg);
+    shade_bg.alpha *= 0.5;
 
 	gdk_cairo_set_source_rgba (cr, highlight ? &fg : &shade_bg);
-#else
-	GtkStyle    *style = gtk_widget_get_style (widget);
-	GtkStateType state = gtk_widget_get_state (widget);
-
-	gdk_cairo_set_source_color (cr, highlight ? &style->text[state] : &style->dark[state]);
-#endif
 	cairo_rectangle (cr,
 			 area->x,
 			 area->y,

--- a/libview/Makefile.am
+++ b/libview/Makefile.am
@@ -131,9 +131,9 @@ XreaderView-$(EV_API_VERSION).gir: libxreaderview.la Makefile $(INST_H_FILES) $(
 	--include=GLib-2.0 \
 	--include=GObject-2.0 \
 	--include=Gio-2.0 \
-	--include=Gdk-$(GTK_API_VERSION) \
+	--include=Gdk-3.0 \
 	--include=GdkPixbuf-2.0 \
-	--include=Gtk-$(GTK_API_VERSION) \
+	--include=Gtk-3.0 \
 	--include=XreaderDocument-$(EV_API_VERSION) \
 	--library=xreaderview \
 	--libtool="$(LIBTOOL)" \

--- a/libview/ev-timeline.c
+++ b/libview/ev-timeline.c
@@ -21,8 +21,6 @@
 
 #include <glib.h>
 #include <math.h>
-#include <gtk/gtk.h>
-#include <gdk/gdk.h>
 #include "ev-timeline.h"
 
 #define EV_TIMELINE_GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EV_TYPE_TIMELINE, EvTimelinePriv))

--- a/shell/eggfindbar.c
+++ b/shell/eggfindbar.c
@@ -162,23 +162,6 @@ egg_find_bar_class_init (EggFindBarClass *klass)
                                                          FALSE,
                                                          G_PARAM_READWRITE));
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  /* Style properties */
-  gtk_widget_class_install_style_property (widget_class,
-                                           g_param_spec_boxed ("all_matches_color",
-                                                               "Highlight color",
-                                                               "Color of highlight for all matches",
-                                                               GDK_TYPE_COLOR,
-                                                               G_PARAM_READABLE));
-
-  gtk_widget_class_install_style_property (widget_class,
-                                           g_param_spec_boxed ("current_match_color",
-                                                               "Current color",
-                                                               "Color of highlight for the current match",
-                                                               GDK_TYPE_COLOR,
-                                                               G_PARAM_READABLE));
-#endif
-
   g_type_class_add_private (object_class, sizeof (EggFindBarPrivate));
 
   binding_set = gtk_binding_set_by_class (klass);
@@ -666,63 +649,6 @@ egg_find_bar_get_case_sensitive (EggFindBar *find_bar)
 
   return priv->case_sensitive;
 }
-
-#if !GTK_CHECK_VERSION (3, 0, 0)
-static void
-get_style_color (EggFindBar *find_bar,
-                 const char *style_prop_name,
-                 GdkColor   *color)
-{
-  GdkColor *style_color;
-
-  gtk_widget_ensure_style (GTK_WIDGET (find_bar));
-  gtk_widget_style_get (GTK_WIDGET (find_bar),
-                        "color", &style_color, NULL);
-  if (style_color)
-    {
-      *color = *style_color;
-      gdk_color_free (style_color);
-    }
-}
-
-/**
- * egg_find_bar_get_all_matches_color:
- *
- * Gets the color to use to highlight all the
- * known matches.
- *
- * Since: 2.6
- */
-void
-egg_find_bar_get_all_matches_color (EggFindBar *find_bar,
-                                    GdkColor   *color)
-{
-  GdkColor found_color = { 0, 0, 0, 0x0f0f };
-
-  get_style_color (find_bar, "all_matches_color", &found_color);
-
-  *color = found_color;
-}
-
-/**
- * egg_find_bar_get_current_match_color:
- *
- * Gets the color to use to highlight the match
- * we're currently on.
- *
- * Since: 2.6
- */
-void
-egg_find_bar_get_current_match_color (EggFindBar *find_bar,
-                                      GdkColor   *color)
-{
-  GdkColor found_color = { 0, 0, 0, 0xffff };
-
-  get_style_color (find_bar, "current_match_color", &found_color);
-
-  *color = found_color;
-}
-#endif
 
 /**
  * egg_find_bar_set_status_text:

--- a/shell/eggfindbar.h
+++ b/shell/eggfindbar.h
@@ -68,10 +68,6 @@ const char* egg_find_bar_get_search_string       (EggFindBar *find_bar);
 void        egg_find_bar_set_case_sensitive      (EggFindBar *find_bar,
                                                   gboolean    case_sensitive);
 gboolean    egg_find_bar_get_case_sensitive      (EggFindBar *find_bar);
-void        egg_find_bar_get_all_matches_color   (EggFindBar *find_bar,
-                                                  GdkColor   *color);
-void        egg_find_bar_get_current_match_color (EggFindBar *find_bar,
-                                                  GdkColor   *color);
 void        egg_find_bar_set_status_text         (EggFindBar *find_bar,
                                                   const char *text);
 

--- a/shell/ev-application.c
+++ b/shell/ev-application.c
@@ -264,12 +264,7 @@ ev_spawn (const char     *uri,
 		GList uri_list;
 		GList *uris = NULL;
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 		ctx = gdk_display_get_app_launch_context (gdk_screen_get_display (screen));
-#else
-		ctx = gdk_app_launch_context_new ();
-		gdk_app_launch_context_set_display (ctx, gdk_screen_get_display (screen));
-#endif
 		gdk_app_launch_context_set_screen (ctx, screen);
 		gdk_app_launch_context_set_timestamp (ctx, timestamp);
 

--- a/shell/ev-sidebar-thumbnails.c
+++ b/shell/ev-sidebar-thumbnails.c
@@ -685,14 +685,11 @@ static void
 ev_sidebar_init_icon_view (EvSidebarThumbnails *ev_sidebar_thumbnails)
 {
 	EvSidebarThumbnailsPrivate *priv;
-#if GTK_CHECK_VERSION (3, 0, 0)
 	GtkCellRenderer *renderer;
-#endif
 
 	priv = ev_sidebar_thumbnails->priv;
 
 	priv->icon_view = gtk_icon_view_new_with_model (GTK_TREE_MODEL (priv->list_store));
-#if GTK_CHECK_VERSION (3, 0, 0)
 	renderer = g_object_new (GTK_TYPE_CELL_RENDERER_PIXBUF,
 				 "xalign", 0.5,
 				 "yalign", 1.0,
@@ -712,10 +709,6 @@ ev_sidebar_init_icon_view (EvSidebarThumbnails *ev_sidebar_thumbnails)
 	gtk_cell_layout_pack_end (GTK_CELL_LAYOUT (priv->icon_view), renderer, FALSE);
 	gtk_cell_layout_set_attributes (GTK_CELL_LAYOUT (priv->icon_view),
 					renderer, "markup", 0, NULL);
-#else
-	gtk_icon_view_set_markup_column (GTK_ICON_VIEW (priv->icon_view), 0);
-	gtk_icon_view_set_pixbuf_column (GTK_ICON_VIEW (priv->icon_view), 1);
-#endif
 	g_signal_connect (priv->icon_view, "selection-changed",
 			  G_CALLBACK (ev_sidebar_icon_selection_changed), ev_sidebar_thumbnails);
 
@@ -750,11 +743,7 @@ ev_sidebar_thumbnails_init (EvSidebarThumbnails *ev_sidebar_thumbnails)
 	 * it's just a workaround for bug #449462 (GTK2 only)
 	 */
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (priv->swindow),
-#if GTK_CHECK_VERSION (3, 0, 0)
 					GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
-#else
-					GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-#endif
 	gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (priv->swindow),
 					     GTK_SHADOW_IN);
 	priv->vadjustment = gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (priv->swindow));

--- a/shell/ev-utils.c
+++ b/shell/ev-utils.c
@@ -225,11 +225,7 @@ ev_gui_sanitise_popup_position (GtkMenu *menu,
 
 	g_return_if_fail (widget != NULL);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_get_preferred_size (GTK_WIDGET (menu), &req, NULL);
-#else
-	gtk_widget_size_request (GTK_WIDGET (menu), &req);
-#endif
 
 	monitor_num = gdk_screen_get_monitor_at_point (screen, *x, *y);
 	gtk_menu_set_monitor (menu, monitor_num);
@@ -255,11 +251,7 @@ ev_gui_menu_position_tree_selection (GtkMenu   *menu,
 	GtkAllocation allocation;
 	GdkRectangle visible;
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_get_preferred_size (GTK_WIDGET (menu), &req, NULL);
-#else
-	gtk_widget_size_request (GTK_WIDGET (menu), &req);
-#endif
 	gdk_window_get_origin (gtk_widget_get_window (widget), x, y);
 	gtk_widget_get_allocation (widget, &allocation);
 


### PR DESCRIPTION
… and --with-gtk build option"

We split the commit below into several parts. This is part 2.
  - Clean up code from GTK2 leftovers

commit ae5f4711a21508a70d7123dbc0efb610af1289a2
Author: monsta <monsta@inbox.ru>
Date:   Wed Nov 23 18:15:54 2016 +0300

    move to GTK+3 (>= 3.14), drop GTK+2 code and --with-gtk build option

    and require caja >= 1.17.1