### PR TITLE
Backports from Atril 1.17.0 Patch c

### DIFF
--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -93,7 +93,7 @@ static gboolean      new_selection_surface_needed(EvPixbufCache      *pixbuf_cac
 #define PAGE_CACHE_LEN(pixbuf_cache) \
 	(pixbuf_cache->start_page>=0?((pixbuf_cache->end_page - pixbuf_cache->start_page) + 1):0)
 
-#define MAX_PRELOADED_PAGES 3
+#define MAX_PRELOADED_PAGES 20
 
 G_DEFINE_TYPE (EvPixbufCache, ev_pixbuf_cache, G_TYPE_OBJECT)
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -740,12 +740,13 @@ view_update_range_and_current_page (EvView *view)
 		}
 	}
 
+	#define PAGE_CACHE_NUMBER  10
 	ev_page_cache_set_page_range (view->page_cache,
-				      view->start_page,
-				      view->end_page);
+				      MAX(view->start_page - PAGE_CACHE_NUMBER, 0),
+				      MIN(view->end_page + PAGE_CACHE_NUMBER, ev_document_get_n_pages (view->document) - 1));
 	ev_pixbuf_cache_set_page_range (view->pixbuf_cache,
-					view->start_page,
-					view->end_page,
+					MAX(view->start_page - PAGE_CACHE_NUMBER, 0),
+					MIN(view->end_page + PAGE_CACHE_NUMBER, ev_document_get_n_pages (view->document) - 1),
 					view->selection_info.selections);
 
 	if (ev_pixbuf_cache_get_surface (view->pixbuf_cache, view->current_page))

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1199,8 +1199,6 @@ setup_document_from_metadata (EvWindow *window)
 	 * show the first page. */
 	page = ev_document_model_get_page (window->priv->model);
 	n_pages = ev_document_get_n_pages (window->priv->document);
-	if (page == n_pages - 1)
-		ev_document_model_set_page (window->priv->model, 0);
 
 	if (ev_metadata_get_int (window->priv->metadata, "window_width", &width) &&
 	    ev_metadata_get_int (window->priv->metadata, "window_height", &height))


### PR DESCRIPTION
- Faster thumbnail/page loading (bigger page cache)
- small page offset fix when reopening an already opened document that has been closed while on last page.