### PR TITLE
Switch zoom buttons in toolbar

### DIFF
--- a/previewer/previewer-ui.xml
+++ b/previewer/previewer-ui.xml
@@ -7,8 +7,8 @@
     <separator/>
     <toolitem name="ViewPageWidth" action="ViewPageWidth"/>
     <toolitem name="ViewBestFit" action="ViewBestFit"/>
-    <toolitem name="ViewZoomIn" action="ViewZoomIn"/>
     <toolitem name="ViewZoomOut" action="ViewZoomOut"/>
+    <toolitem name="ViewZoomIn" action="ViewZoomIn"/>
     <separator/>
     <toolitem name="PreviewPrint" action="PreviewPrint"/>
   </toolbar>

--- a/shell/ev-toolbar.c
+++ b/shell/ev-toolbar.c
@@ -219,12 +219,12 @@ ev_toolbar_constructed (GObject *object)
     ev_toolbar->priv->expand_window_button = create_button (action);
     gtk_box_pack_end (GTK_BOX (box), ev_toolbar->priv->expand_window_button, FALSE, FALSE, 0);
 
-    action = gtk_action_group_get_action (action_group, "ViewZoomOut");
+    action = gtk_action_group_get_action (action_group, "ViewZoomIn");
     button = create_button (action);
     gtk_box_pack_end (GTK_BOX (box), button, FALSE, FALSE, 0);
     gtk_widget_show (GTK_WIDGET (button));
 
-    action = gtk_action_group_get_action (action_group, "ViewZoomIn");
+    action = gtk_action_group_get_action (action_group, "ViewZoomOut");
     button = create_button (action);
     gtk_box_pack_end (GTK_BOX (box), button, FALSE, FALSE, 0);
     gtk_widget_show (GTK_WIDGET (button));


### PR DESCRIPTION
Previously: "In" was left, "Out" was right,
now: "Out" is left, "In" is right