### PR TITLE
shell: Make main window title translatable (fix issue #39)

### DIFF
--- a/shell/main.c
+++ b/shell/main.c
@@ -36,7 +36,6 @@
 #include "eggsmclient.h"
 #include "eggdesktopfile.h"
 
-
 static gchar   *ev_page_label;
 static gchar   *ev_find_string;
 static gint     ev_page_index = 0;
@@ -55,9 +54,10 @@ option_version_cb (const gchar *option_name,
                    gpointer     data,
                    GError     **error)
 {
-  g_print ("%s %s\n", _("MATE Document Viewer"), VERSION);
-
+  g_print ("%s %s\n", g_get_application_name(), VERSION);
   exit (0);
+
+  /* Keep compiler quiet */
   return FALSE;
 }
 
@@ -236,7 +236,9 @@ main (int argc, char *argv[])
 
 	gdk_set_allowed_backends ("x11");
 
-	context = g_option_context_new (N_("MATE Document Viewer"));
+	g_set_application_name (_("Xreader Document Viewer"));
+
+	context = g_option_context_new (N_("Xreader Document Viewer"));
 	g_option_context_set_translation_domain(context, GETTEXT_PACKAGE);
 	g_option_context_add_main_entries (context, goption_options, GETTEXT_PACKAGE);
 	g_option_context_add_group (context, egg_sm_client_get_option_group ());
@@ -264,7 +266,7 @@ main (int argc, char *argv[])
 
 	ev_stock_icons_init ();
 
-	egg_set_desktop_file (MATEDATADIR "/applications/xreader.desktop");
+	gtk_window_set_default_icon_name ("accessories-document-viewer");
 
 	ev_application_load_session (EV_APP);
 	load_files (file_arguments);


### PR DESCRIPTION
I introduced a define for XREADER_APPNAME... Is that a problem to automatically detect translation strings, like `_(XREADER_APPNAME)`? If not, it's ready to merge...