### PR TITLE
Fixes "Having selected text leads to high cpu load"

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -144,9 +144,11 @@ ev_document_misc_paint_one_page (cairo_t      *cr,
 	GtkStateFlags state = gtk_widget_get_state_flags (widget);
     GdkRGBA fg, bg, shade_bg;
 
+    gtk_style_context_save (context);
     gtk_style_context_get_background_color (context, state, &bg);
     gtk_style_context_get_color (context, state, &fg);
     gtk_style_context_get_color (context, state, &shade_bg);
+    gtk_style_context_restore (context);
     shade_bg.alpha *= 0.5;
 
 	gdk_cairo_set_source_rgba (cr, highlight ? &fg : &shade_bg);

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -633,6 +633,8 @@ get_selection_colors (GtkWidget *widget, GdkColor *text, GdkColor *base)
 
         state |= gtk_widget_has_focus (widget) ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_ACTIVE;
 
+        gtk_style_context_save (context);
+
         gtk_style_context_get_color (context, state, &fg);
         text->pixel = 0;
         text->red = CLAMP ((guint) (fg.red * 65535), 0, 65535);
@@ -644,6 +646,8 @@ get_selection_colors (GtkWidget *widget, GdkColor *text, GdkColor *base)
         base->red = CLAMP ((guint) (bg.red * 65535), 0, 65535);
         base->green = CLAMP ((guint) (bg.green * 65535), 0, 65535);
         base->blue = CLAMP ((guint) (bg.blue * 65535), 0, 65535);
+
+        gtk_style_context_restore (context);
 }
 
 static void

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4284,7 +4284,9 @@ draw_rubberband (EvView             *view,
 	GdkRGBA          color;
 
 	context = gtk_widget_get_style_context (GTK_WIDGET (view));
+	gtk_style_context_save (context);
 	gtk_style_context_get_background_color (context, GTK_STATE_FLAG_SELECTED, &color);
+	gtk_style_context_restore (context);
 
 	cairo_save (cr);
 	cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha);


### PR DESCRIPTION
Fixes #70

This patch is based on:

  https://git.gnome.org/browse/evince/commit/?id=1987f04ea36329b1bd61d053a19d9e341e0454ce

  author  Sebastian Keller <sebastian-keller@gmx.de>  2015-09-22 21:25:34 (GMT)

  libview: Save/restore context when getting colors for a different state

  Getting colors for a state different from the current state of the
  corresponding widget without saving the context might trigger an
  invalidation and a redraw. Because this was happening from the draw
  function this resulted in a redraw loop and constant high CPU usage.

  This could be triggered by selecting text or searching.

  https://bugzilla.gnome.org/show_bug.cgi?id=755442