### PR TITLE
Fix for 'Inverted Colors won't be saved by Save Current Settings as Default'

### DIFF
--- a/libview/ev-web-view.c
+++ b/libview/ev-web-view.c
@@ -252,7 +252,10 @@ ev_web_view_inverted_colors_changed_cb (EvDocumentModel *model,
 				        EvWebView       *webview)
 {
 	EvDocument *document = ev_document_model_get_document(model);
-	
+
+	if (!document || !document->iswebdocument)
+	    return;
+
 	if (ev_document_model_get_inverted_colors(model) == TRUE) {
 		if (document == NULL) {
 			ev_document_model_set_inverted_colors(model,FALSE);


### PR DESCRIPTION
Fixes #38

The web-view callback for inverted colors got called, and if it did not find a web-view open
it defaulted to FALSE for inverted colors.