### PR TITLE
Document that libcaja-extension is required

### DIFF
--- a/README
+++ b/README
@@ -50,8 +50,9 @@ Building Xreader from source
 1) Install prerequisites:
 
     apt install git dpkg-dev
-    apt install gobject-introspection libnemo-extension-dev libdjvulibre-dev  \
-                libgail-3-dev libgirepository1.0-dev libgtk-3-dev libgxps-dev \
+    apt install gobject-introspection libcaja-extension-dev                   \
+                libnemo-extension-dev libdjvulibre-dev libgail-3-dev          \
+                libgirepository1.0-dev libgtk-3-dev libgxps-dev               \
                 libkpathsea-dev libpoppler-glib-dev libsecret-1-dev           \
                 libspectre-dev libwebkit2gtk-4.0-dev mate-common xsltproc     \
                 yelp-tools


### PR DESCRIPTION
I followed the build instructions on a nearly pristine Mint 18.2
install, but failed to `./configure` because libcaja-extension was
missing. After installing the package, I was able to configure and build
`xreader`. This change notes the dependency in the README.

wchargin-branch: document-libcaja-extension-required