### PR TITLE
Add accelerators: fit-page, full-width, dual-page

### DIFF
--- a/data/xreader-previewer-ui.xml
+++ b/data/xreader-previewer-ui.xml
@@ -19,8 +19,10 @@
   <accelerator name="BackSpaceAccel" action="BackSpace"/>
   <accelerator name="ShiftSpaceAccel" action="ShiftSpace"/>
   <accelerator name="ShiftBackSpaceAccel" action="ShiftBackSpace"/>
-  <accelerator name="pAccel" action="p"/>
+  <accelerator name="fAccel" action="f"/>
   <accelerator name="nAccel" action="n"/>
+  <accelerator name="pAccel" action="p"/>
+  <accelerator name="wAccel" action="w"/>
   <accelerator name="ShiftReturnAccel" action="ShiftReturn"/>
   <accelerator name="FocusPageSelectorAccel" action="FocusPageSelector"/>
   <accelerator name="PlusAccel" action="Plus"/>

--- a/data/xreader-ui.xml
+++ b/data/xreader-ui.xml
@@ -112,8 +112,11 @@
   <accelerator name="BackSpaceAccel" action="BackSpace"/>
   <accelerator name="ShiftSpaceAccel" action="ShiftSpace"/>
   <accelerator name="ShiftBackSpaceAccel" action="ShiftBackSpace"/>
-  <accelerator name="pAccel" action="p"/>
+  <accelerator name="dAccel" action="d"/>
+  <accelerator name="fAccel" action="f"/>
   <accelerator name="nAccel" action="n"/>
+  <accelerator name="pAccel" action="p"/>
+  <accelerator name="wAccel" action="w"/>
   <accelerator name="ShiftReturnAccel" action="ShiftReturn"/>
   <accelerator name="FocusPageSelectorAccel" action="FocusPageSelector"/>
   <accelerator name="PlusAccel" action="Plus"/>

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -136,21 +136,19 @@ ev_previewer_window_zoom_out (GtkAction         *action,
 }
 
 static void
-ev_previewer_window_zoom_best_fit (GtkToggleAction   *action,
-				   EvPreviewerWindow *window)
+ev_previewer_window_zoom_best_fit (GtkToggleAction *action, EvPreviewerWindow *window)
 {
-	ev_document_model_set_sizing_mode (window->model,
-					   gtk_toggle_action_get_active (action) ?
-					   EV_SIZING_BEST_FIT : EV_SIZING_FREE);
+    ev_document_model_set_sizing_mode (window->model,
+            ev_document_model_get_sizing_mode (window->model) == EV_SIZING_BEST_FIT ?
+            EV_SIZING_FREE : EV_SIZING_BEST_FIT);
 }
 
 static void
-ev_previewer_window_zoom_page_width (GtkToggleAction   *action,
-				     EvPreviewerWindow *window)
+ev_previewer_window_zoom_page_width (GtkToggleAction *action, EvPreviewerWindow *window)
 {
-	ev_document_model_set_sizing_mode (window->model,
-					   gtk_toggle_action_get_active (action) ?
-					   EV_SIZING_FIT_WIDTH : EV_SIZING_FREE);
+    ev_document_model_set_sizing_mode (window->model,
+            ev_document_model_get_sizing_mode (window->model) == EV_SIZING_FIT_WIDTH ?
+            EV_SIZING_FREE : EV_SIZING_FIT_WIDTH);
 }
 
 static void
@@ -316,10 +314,14 @@ static const GtkActionEntry accel_entries[] = {
 	  G_CALLBACK (ev_previewer_window_scroll_forward) },
 	{ "ShiftReturn", NULL, "", "<shift>Return", NULL,
 	  G_CALLBACK (ev_previewer_window_scroll_backward) },
-	{ "p", GTK_STOCK_GO_UP, "", "p", NULL,
-	  G_CALLBACK (ev_previewer_window_previous_page) },
+	{ "f", EV_STOCK_ZOOM_PAGE, "", "f", NULL,
+	  G_CALLBACK (ev_previewer_window_zoom_best_fit) },
 	{ "n", GTK_STOCK_GO_DOWN, "", "n", NULL,
 	  G_CALLBACK (ev_previewer_window_next_page) },
+	{ "p", GTK_STOCK_GO_UP, "", "p", NULL,
+	  G_CALLBACK (ev_previewer_window_previous_page) },
+	{ "w", EV_STOCK_ZOOM_WIDTH, "", "w", NULL,
+	  G_CALLBACK (ev_previewer_window_zoom_page_width) },
 	{ "Plus", GTK_STOCK_ZOOM_IN, NULL, "plus", NULL,
 	  G_CALLBACK (ev_previewer_window_zoom_in) },
 	{ "CtrlEqual", GTK_STOCK_ZOOM_IN, NULL, "<control>equal", NULL,

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -564,8 +564,11 @@ ev_window_set_view_accels_sensitivity (EvWindow *window, gboolean sensitive)
 		ev_window_set_action_sensitive (window, "KpPlus", sensitive);
 		ev_window_set_action_sensitive (window, "KpMinus", sensitive);
 		ev_window_set_action_sensitive (window, "Equal", sensitive);
-		ev_window_set_action_sensitive (window, "p", sensitive);
+		ev_window_set_action_sensitive (window, "d", sensitive);
+		ev_window_set_action_sensitive (window, "f", sensitive);
 		ev_window_set_action_sensitive (window, "n", sensitive);
+		ev_window_set_action_sensitive (window, "p", sensitive);
+		ev_window_set_action_sensitive (window, "w", sensitive);
 
 		ev_window_set_action_sensitive (window, "Slash", sensitive && can_find);
 	}
@@ -3729,11 +3732,11 @@ ev_window_cmd_continuous (GtkAction *action, EvWindow *ev_window)
 static void
 ev_window_cmd_dual (GtkAction *action, EvWindow *ev_window)
 {
-	gboolean dual_page;
+    gboolean was_dual_page;
 
-	ev_window_stop_presentation (ev_window, TRUE);
-	dual_page = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
-	ev_document_model_set_dual_page (ev_window->priv->model, dual_page);
+    ev_window_stop_presentation (ev_window, TRUE);
+    was_dual_page = ev_document_model_get_dual_page (ev_window->priv->model);
+    ev_document_model_set_dual_page (ev_window->priv->model, !was_dual_page);
 }
 
 static void
@@ -3750,27 +3753,27 @@ ev_window_cmd_dual_odd_pages_left (GtkAction *action, EvWindow *ev_window)
 static void
 ev_window_cmd_view_best_fit (GtkAction *action, EvWindow *ev_window)
 {
-	ev_window_stop_presentation (ev_window, TRUE);
+    ev_window_stop_presentation (ev_window, TRUE);
 
-	if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action))) {
-		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_BEST_FIT);
-	} else {
-		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FREE);
-	}
-	ev_window_update_actions (ev_window);
+    if (ev_document_model_get_sizing_mode (ev_window->priv->model) == EV_SIZING_BEST_FIT) {
+        ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FREE);
+    } else {
+        ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_BEST_FIT);
+    }
+    ev_window_update_actions (ev_window);
 }
 
 static void
 ev_window_cmd_view_page_width (GtkAction *action, EvWindow *ev_window)
 {
-	ev_window_stop_presentation (ev_window, TRUE);
+    ev_window_stop_presentation (ev_window, TRUE);
 
-	if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action))) {
-		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FIT_WIDTH);
-	} else {
-		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FREE);
-	}
-	ev_window_update_actions (ev_window);
+    if (ev_document_model_get_sizing_mode (ev_window->priv->model) == EV_SIZING_FIT_WIDTH) {
+        ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FREE);
+    } else {
+        ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FIT_WIDTH);
+    }
+    ev_window_update_actions (ev_window);
 }
 
 
@@ -5876,10 +5879,16 @@ static const GtkActionEntry entries[] = {
           G_CALLBACK (ev_window_cmd_scroll_forward) },
         { "ShiftReturn", NULL, "", "<shift>Return", NULL,
           G_CALLBACK (ev_window_cmd_scroll_backward) },
-	{ "p", GTK_STOCK_GO_UP, "", "p", NULL,
-	  G_CALLBACK (ev_window_cmd_go_previous_page) },
-	{ "n", GTK_STOCK_GO_DOWN, "", "n", NULL,
-	  G_CALLBACK (ev_window_cmd_go_next_page) },
+        { "d", EV_STOCK_VIEW_DUAL, "", "d", NULL,
+          G_CALLBACK (ev_window_cmd_dual) },
+        { "f", EV_STOCK_ZOOM_PAGE, "", "f", NULL,
+          G_CALLBACK (ev_window_cmd_view_best_fit) },
+        { "n", GTK_STOCK_GO_DOWN, "", "n", NULL,
+          G_CALLBACK (ev_window_cmd_go_next_page) },
+        { "p", GTK_STOCK_GO_UP, "", "p", NULL,
+          G_CALLBACK (ev_window_cmd_go_previous_page) },
+        { "w", EV_STOCK_ZOOM_WIDTH, "", "w", NULL,
+          G_CALLBACK (ev_window_cmd_view_page_width) },
         { "Plus", GTK_STOCK_ZOOM_IN, NULL, "plus", NULL,
           G_CALLBACK (ev_window_cmd_view_zoom_in) },
         { "CtrlEqual", GTK_STOCK_ZOOM_IN, NULL, "<control>equal", NULL,


### PR DESCRIPTION
Summary:
This commit adds support for accelerators `f` (fit page in window),
`w` (fill window width with page), and `d` (toggle dual-page display).
These accelerators are present in evince and are extremely commonly used
(at least by me!). The previewer supports only `f` and `w`, as it does
not include a dual-page display option.

This fixes #30. This was previously attempted in #57, but the
implementation was flawed: it neglected to disable the accelerators when
search was active, and as a consequence it was not possible to search
for strings containing `f`, `w`, or `d`.

To implement this, I changed slightly the logic of the callbacks for the
fit-page, fill-window, and dual-page actions. These actions used to use
the GUI as the source of truth; now they use the model as the source of
truth. (This is necessary because the GUI items for the toggle buttons
are not (easily) accessible when invoked from an accelerator context.
Furthermore, separating the source of truth from the UI generally proves
to be a Good Idea, anyway.)

In places where I modified existing code, I brought it up to date with
the [style guide] (in particular, replacing tabs with four spaces for
indentation).

[style guide]: https://linuxmint.gitbooks.io/developer-guidelines/content/coding_style.html#no-tabs

Test Plan:
Test that the `f`, `w`, and `d` accelerators cause the appropriate
action to be taken, and also result in the menu items' toggled state
updating to the correct value (e.g., after you press `f`, the "Best Fit"
menu item is checked, and when you press `f` again it is unchecked).
Test that you can search (<C-f> or Slash) for strings starting with
and/or containing the characters `f`, `w`, or `d` (and that the
accelerators do not trigger when you press these keys). Further test
that the same behavior holds in the previewer (except for dual-page
display and search, which the preview does not support).

Note that you should invoke the previewer as
`$INSTALL/bin/xreader-previewer` (where `$INSTALL` is your install
directory)  rather than `$INSTALL/bin/xreader -w`, for the latter will
use the `xreader-previewer` on your system path, which is likely not the
same as the development target.

In no cases are there additional warnings on the console.

wchargin-branch: add-f-w-d-accelerators