### PR TITLE
ATRIL BACKPORTS: comics: make the files containing "--checkpoint-action=" unsupported

### DIFF
--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -983,6 +983,12 @@ extract_argv (EvDocument *document, gint page)
 	char *command_line, *quoted_archive, *quoted_filename;
 	GError *err = NULL;
 
+	if (g_strrstr (comics_document->page_names->pdata[page], "--checkpoint-action="))
+	{
+		g_warning ("File unsupported\n");
+		gtk_main_quit ();
+	}
+
         if (page >= comics_document->page_names->len)
                 return NULL;
 


### PR DESCRIPTION
Commit 7de8e2c from Wed Jul 19 11:00:09 2017 +0200 by ZenWalker

comics: make the files containing "--checkpoint-action=" unsupported

Fixes #150