### PR TITLE
LIBDOC01: Use of gdbus-codegen for xreader's Application, Window and Daemon interfaces

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,9 +158,15 @@ AS_IF([test "x$found_zlib" = "xno"], [
   AC_SUBST(ZLIB_LIBS)
 ])
 
-dnl
-dnl SM client
-dnl
+AC_ARG_VAR([GDBUS_CODEGEN],[the gdbus-codegen programme])
+AC_PATH_PROG([GDBUS_CODEGEN],[gdbus-codegen],[])
+if test -z "$GDBUS_CODEGEN"; then
+  AC_MSG_ERROR([gdbus-codegen not found])
+fi
+
+# *********
+# SM client
+# *********
 
 PKG_CHECK_MODULES([SMCLIENT],[gtk+-3.0 gthread-2.0 sm >= 1.0.0])
 AC_SUBST([SMCLIENT_CFLAGS])

--- a/help/reference/shell/Makefile.am
+++ b/help/reference/shell/Makefile.am
@@ -17,7 +17,7 @@ DOC_MAIN_SGML_FILE = $(DOC_MODULE)-docs.xml
 
 # The directory containing the source code. Relative to $(srcdir).
 # gtk-doc will search all .c & .h files beneath here for inline comments
-# xreadering the functions and macros.
+# evinceing the functions and macros.
 # e.g. DOC_SOURCE_DIR=../../../gtk
 DOC_SOURCE_DIR = $(top_srcdir)/shell
 
@@ -110,7 +110,8 @@ GTKDOC_CFLAGS = \
 
 FILTER_OUT = \
 	$(top_builddir)/shell/main.o			\
-	$(top_builddir)/shell/xreaderd-ev-daemon.o
+	$(top_builddir)/shell/xreaderd-ev-daemon.o \
+	$(top_builddir)/shell/xreaderd-ev-daemon-gdbus-generated.o
 
 GTKDOC_LIBS = \
 	$(top_builddir)/cut-n-paste/zoom-control/libephyzoom.la		\

--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -1,3 +1,5 @@
+NULL =
+
 AM_CPPFLAGS=							\
 	-DXREADERDATADIR=\"$(pkgdatadir)\"				\
 	-DXREADER_LOCALE_DIR=\"$(datadir)/locale\"	\
@@ -130,12 +132,22 @@ BUILT_SOURCES = \
 	ev-resources.c
 
 if ENABLE_DBUS
-BUILT_SOURCES += ev-gdbus-generated.c ev-gdbus-generated.h
+BUILT_SOURCES += \
+	ev-gdbus-generated.c \
+	ev-gdbus-generated.h \
+	ev-daemon-gdbus-generated.c \
+	ev-daemon-gdbus-generated.h
 endif
 
 if ENABLE_DBUS
-xreaderd_SOURCES=			\
-	ev-daemon.c
+xreaderd_SOURCES = \
+	ev-daemon.c \
+	$(NULL)
+
+nodist_xreaderd_SOURCES = \
+	ev-daemon-gdbus-generated.c \
+	ev-daemon-gdbus-generated.h
+	$(NULL)
 
 xreaderd_CFLAGS=				\
 	-DXREADERDATADIR=\"$(pkgdatadir)\"			\
@@ -156,7 +168,8 @@ EXTRA_DIST = \
 	ev-marshal.list \
 	xreader-ui.xml \
 	xreader.gresource.xml \
-	ev-gdbus.xml
+	ev-gdbus.xml \
+	ev-daemon-gdbus.xml
 
 ev-marshal.h: $(srcdir)/ev-marshal.list
 	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=ev_marshal $(srcdir)/ev-marshal.list --header > ev-marshal.h
@@ -176,6 +189,14 @@ ev-gdbus-generated.c ev-gdbus-generated.h: ev-gdbus.xml Makefile
 			--generate-c-code ev-gdbus-generated \
 			$<
 
-DISTCLEANFILES =
+ev-daemon-gdbus-generated.c ev-daemon-gdbus-generated.h: ev-daemon-gdbus.xml Makefile
+	$(AM_V_GEN) $(GDBUS_CODEGEN) \
+			--interface-prefix=org.x.reader \
+			--c-namespace=Ev \
+			--c-generate-object-manager \
+			--generate-c-code ev-daemon-gdbus-generated \
+			$<
+
+DISTCLEANFILES = $(BUILT_SOURCES)
 
 -include $(top_srcdir)/git.mk

--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -96,6 +96,13 @@ xreader_SOURCES=				\
 	ev-sidebar-thumbnails.h		\
 	main.c
 
+if ENABLE_DBUS
+nodist_xreader_SOURCES = \
+	ev-gdbus-generated.c \
+	ev-gdbus-generated.h \
+	$(NULL)
+endif
+
 xreader_LDFLAGS = $(AM_LDFLAGS)
 
 xreader_LDADD=										\
@@ -123,6 +130,10 @@ BUILT_SOURCES = \
 	ev-resources.c
 
 if ENABLE_DBUS
+BUILT_SOURCES += ev-gdbus-generated.c ev-gdbus-generated.h
+endif
+
+if ENABLE_DBUS
 xreaderd_SOURCES=			\
 	ev-daemon.c
 
@@ -144,7 +155,8 @@ endif
 EXTRA_DIST = \
 	ev-marshal.list \
 	xreader-ui.xml \
-	xreader.gresource.xml
+	xreader.gresource.xml \
+	ev-gdbus.xml
 
 ev-marshal.h: $(srcdir)/ev-marshal.list
 	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=ev_marshal $(srcdir)/ev-marshal.list --header > ev-marshal.h
@@ -155,6 +167,14 @@ ev-marshal.c: $(srcdir)/ev-marshal.list
 
 ev-resources.c: xreader.gresource.xml Makefile $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies --sourcedir $(srcdir) $(srcdir)/xreader.gresource.xml)
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir $(srcdir) --generate-source --c-name ev $<
+
+ev-gdbus-generated.c ev-gdbus-generated.h: ev-gdbus.xml Makefile
+	$(AM_V_GEN) $(GDBUS_CODEGEN) \
+			--interface-prefix=org.x.reader \
+			--c-namespace=Ev \
+			--c-generate-object-manager \
+			--generate-c-code ev-gdbus-generated \
+			$<
 
 DISTCLEANFILES =
 

--- a/shell/ev-application.c
+++ b/shell/ev-application.c
@@ -40,6 +40,10 @@
 #include "ev-file-helpers.h"
 #include "ev-stock-icons.h"
 
+#ifdef ENABLE_DBUS
+#include "ev-gdbus-generated.h"
+#endif /* ENABLE_DBUS */
+
 struct _EvApplication {
 	GObject base_instance;
 
@@ -49,7 +53,7 @@ struct _EvApplication {
 
 #ifdef ENABLE_DBUS
 	GDBusConnection *connection;
-        guint registration_id;
+	EvXreaderApplication *skeleton;
 	gboolean doc_registered;
 #endif
 
@@ -596,17 +600,20 @@ ev_application_open_uri_in_window (EvApplication  *application,
                                    const gchar    *search_string,
                                    guint           timestamp)
 {
-    if (screen) {
-        ev_stock_icons_set_screen (screen);
-        gtk_window_set_screen (GTK_WINDOW (ev_window), screen);
-    }
+	if (uri == NULL)
+		uri = application->uri;
 
-    /* We need to load uri before showing the window, so
-       we can restore window size without flickering */
-    ev_window_open_uri (ev_window, uri, dest, mode, search_string);
+	if (screen) {
+		ev_stock_icons_set_screen (screen);
+		gtk_window_set_screen (GTK_WINDOW (ev_window), screen);
+	}
 
-    if (!gtk_widget_get_realized (GTK_WIDGET (ev_window)))
-        gtk_widget_realize (GTK_WIDGET (ev_window));
+	/* We need to load uri before showing the window, so
+	   we can restore window size without flickering */
+	ev_window_open_uri (ev_window, uri, dest, mode, search_string);
+
+	if (!gtk_widget_get_realized (GTK_WIDGET (ev_window)))
+		gtk_widget_realize (GTK_WIDGET (ev_window));
 
 #ifdef GDK_WINDOWING_X11
     GdkWindow *gdk_window = gtk_widget_get_window (GTK_WIDGET (ev_window));
@@ -720,115 +727,97 @@ ev_application_open_window (EvApplication *application,
 }
 
 #ifdef ENABLE_DBUS
-static void
-method_call_cb (GDBusConnection       *connection,
-                const gchar           *sender,
-                const gchar           *object_path,
-                const gchar           *interface_name,
-                const gchar           *method_name,
-                GVariant              *parameters,
-                GDBusMethodInvocation *invocation,
-                gpointer               user_data)
+static gboolean
+handle_get_window_list_cb (EvXreaderApplication   *object,
+						   GDBusMethodInvocation *invocation,
+                           EvApplication         *application)
 {
-        EvApplication   *application = EV_APPLICATION (user_data);
+        GList     *windows, *l;
+        GPtrArray *paths;
+
+        paths = g_ptr_array_new ();
+
+        windows = ev_application_get_windows (application);
+        for (l = windows; l; l = g_list_next (l)) {
+                EvWindow *window = (EvWindow *)l->data;
+
+                g_ptr_array_add (paths, (gpointer) ev_window_get_dbus_object_path (window));
+        }
+        g_list_free (windows);
+
+        g_ptr_array_add (paths, NULL);
+        ev_xreader_application_complete_get_window_list (object, invocation,
+                                                        (const char * const *) paths->pdata);
+
+        g_ptr_array_free (paths, TRUE);
+
+        return TRUE;
+}
+
+static gboolean
+handle_reload_cb (EvXreaderApplication   *object,
+                  GDBusMethodInvocation *invocation,
+                  GVariant              *args,
+                  guint                  timestamp,
+                  EvApplication         *application)
+{
 	GList           *windows, *l;
-        guint            timestamp;
-        GVariantIter    *iter;
-        const gchar     *key;
-        GVariant        *value;
-        GdkDisplay      *display = NULL;
-        int              screen_number = 0;
+    GVariantIter     iter;
+    const gchar     *key;
+    GVariant        *value;
+    GdkDisplay      *display = NULL;
+    int              screen_number = 0;
 	EvLinkDest      *dest = NULL;
 	EvWindowRunMode  mode = EV_WINDOW_MODE_NORMAL;
 	const gchar     *search_string = NULL;
 	GdkScreen       *screen = NULL;
 
-	if (g_strcmp0 (method_name, "Reload") == 0) {
-		g_variant_get (parameters, "(a{sv}u)", &iter, &timestamp);
+    g_variant_iter_init (&iter, args);
 
-		while (g_variant_iter_loop (iter, "{&sv}", &key, &value)) {
-			if (strcmp (key, "display") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
-				display = ev_display_open_if_needed (g_variant_get_string (value, NULL));
-			} else if (strcmp (key, "screen") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
-				screen_number = g_variant_get_int32 (value);
-			} else if (strcmp (key, "mode") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_UINT32) {
-			mode = g_variant_get_uint32 (value);
-			} else if (strcmp (key, "page-label") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
-				dest = ev_link_dest_new_page_label (g_variant_get_string (value, NULL));
-			} else if (strcmp (key, "named-dest") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
-				dest = ev_link_dest_new_named (g_variant_get_string (value, NULL));
-			} else if (strcmp (key, "page-index") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_UINT32) {
-				dest = ev_link_dest_new_page (g_variant_get_uint32 (value));
-			} else if (strcmp (key, "find-string") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
-				search_string = g_variant_get_string (value, NULL);
-			}
+    while (g_variant_iter_loop (&iter, "{&sv}", &key, &value)) {
+		if (strcmp (key, "display") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
+			display = ev_display_open_if_needed (g_variant_get_string (value, NULL));
+        } else if (strcmp (key, "screen") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_INT32) {
+			screen_number = g_variant_get_int32 (value);
+		} else if (strcmp (key, "mode") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_UINT32) {
+                            mode = g_variant_get_uint32 (value);
+		} else if (strcmp (key, "page-label") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
+			dest = ev_link_dest_new_page_label (g_variant_get_string (value, NULL));
+		} else if (strcmp (key, "named-dest") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
+			dest = ev_link_dest_new_named (g_variant_get_string (value, NULL));
+                    } else if (strcmp (key, "page-index") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_UINT32) {
+                            dest = ev_link_dest_new_page (g_variant_get_uint32 (value));
+		} else if (strcmp (key, "find-string") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
+			search_string = g_variant_get_string (value, NULL);
 		}
-		g_variant_iter_free (iter);
-
-		if (display != NULL &&
-		    screen_number >= 0 &&
-		    screen_number < gdk_display_get_n_screens (display))
-			screen = gdk_display_get_screen (display, screen_number);
-		else
-			screen = gdk_screen_get_default ();
-
-		windows = ev_application_get_windows (application);
-		for (l = windows; l != NULL; l = g_list_next (l)) {
-			EvWindow *ev_window = EV_WINDOW (l->data);
-
-			ev_application_open_uri_in_window (application, application->uri,
-							   ev_window,
-							   screen, dest, mode,
-							   search_string,
-							   timestamp);
-		}
-		g_list_free (windows);
-
-		if (dest)
-			g_object_unref (dest);
-
-		g_dbus_method_invocation_return_value (invocation, g_variant_new ("()"));
-	} else if (g_strcmp0 (method_name, "GetWindowList") == 0) {
-		GList          *windows = ev_application_get_windows (application);
-		GVariantBuilder builder;
-		GList	       *l;
-
-		g_variant_builder_init (&builder, G_VARIANT_TYPE ("(ao)"));
-		g_variant_builder_open (&builder, G_VARIANT_TYPE ("ao"));
-
-		for (l = windows; l; l = g_list_next (l)) {
-			EvWindow *window = (EvWindow *)l->data;
-
-			g_variant_builder_add (&builder, "o", ev_window_get_dbus_object_path (window));
-		}
-
-		g_variant_builder_close (&builder);
-		g_list_free (windows);
-
-		g_dbus_method_invocation_return_value (invocation, g_variant_builder_end (&builder));
 	}
+
+	if (display != NULL &&
+	    screen_number >= 0 &&
+	    screen_number < gdk_display_get_n_screens (display))
+		screen = gdk_display_get_screen (display, screen_number);
+	else
+		screen = gdk_screen_get_default ();
+
+	windows = ev_application_get_windows (application);
+	for (l = windows; l != NULL; l = g_list_next (l)) {
+		EvWindow *ev_window = EV_WINDOW (l->data);
+
+        ev_application_open_uri_in_window (application, NULL,
+						   ev_window,
+						   screen, dest, mode,
+						   search_string,
+						   timestamp);
+	}
+	g_list_free (windows);
+
+	if (dest)
+		g_object_unref (dest);
+
+    ev_xreader_application_complete_reload (object, invocation);
+
+    return TRUE;
 }
-
-static const char introspection_xml[] =
-        "<node>"
-          "<interface name='org.x.reader.Application'>"
-            "<method name='Reload'>"
-              "<arg type='a{sv}' name='args' direction='in'/>"
-              "<arg type='u' name='timestamp' direction='in'/>"
-            "</method>"
-            "<method name='GetWindowList'>"
-              "<arg type='ao' name='window_list' direction='out'/>"
-            "</method>"
-          "</interface>"
-        "</node>";
-
-static const GDBusInterfaceVTable interface_vtable = {
-	method_call_cb,
-	NULL,
-	NULL
-};
-
-static GDBusNodeInfo *introspection_data;
 #endif /* ENABLE_DBUS */
 
 void
@@ -920,18 +909,14 @@ ev_application_shutdown (EvApplication *application)
 	application->scr_saver = NULL;
 
 #ifdef ENABLE_DBUS
-        if (application->registration_id != 0) {
-                g_dbus_connection_unregister_object (application->connection,
-                                                     application->registration_id);
-                application->registration_id = 0;
-        }
-        if (application->connection != NULL) {
-                g_object_unref (application->connection);
-                application->connection = NULL;
-        }
-	if (introspection_data) {
-		g_dbus_node_info_ref (introspection_data);
-		introspection_data = NULL;
+    if (application->skeleton != NULL) {
+            g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (application->skeleton));
+            g_object_unref (application->skeleton);
+            application->skeleton = NULL;
+    }
+    if (application->connection != NULL) {
+            g_object_unref (application->connection);
+            application->connection = NULL;
 	}
 #endif /* ENABLE_DBUS */
 
@@ -969,26 +954,31 @@ static void ev_application_init(EvApplication* ev_application)
 	ev_application_accel_map_load (ev_application);
 
 #ifdef ENABLE_DBUS
-        ev_application->connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
-        if (ev_application->connection != NULL) {
-                introspection_data = g_dbus_node_info_new_for_xml (introspection_xml, NULL);
-                g_assert (introspection_data != NULL);
+    ev_application->connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
+    if (ev_application->connection != NULL) {
+        EvXreaderApplication *skeleton;
 
-                ev_application->registration_id =
-                    g_dbus_connection_register_object (ev_application->connection,
-                                                       APPLICATION_DBUS_OBJECT_PATH,
-                                                       introspection_data->interfaces[0],
-                                                       &interface_vtable,
-                                                       ev_application, NULL,
-                                                       &error);
-                if (ev_application->registration_id == 0) {
-                        g_printerr ("Failed to register bus object: %s\n", error->message);
-                        g_error_free (error);
-                }
+        skeleton = ev_xreader_application_skeleton_new ();
+        if (g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (skeleton),
+                                              ev_application->connection,
+                                              APPLICATION_DBUS_OBJECT_PATH,
+                                              &error)) {
+                ev_application->skeleton = skeleton;
+                g_signal_connect (skeleton, "handle-get-window-list",
+                                  G_CALLBACK (handle_get_window_list_cb),
+                                  ev_application);
+                g_signal_connect (skeleton, "handle-reload",
+                                  G_CALLBACK (handle_reload_cb),
+                                  ev_application);
         } else {
-                g_printerr ("Failed to get bus connection: %s\n", error->message);
-                g_error_free (error);
+            g_object_unref (skeleton);
+            g_printerr ("Failed to register bus object: %s\n", error->message);
+            g_error_free (error);
         }
+    } else {
+        g_printerr ("Failed to get bus connection: %s\n", error->message);
+        g_error_free (error);
+    }
 
 #endif /* ENABLE_DBUS */
 

--- a/shell/ev-daemon-gdbus.xml
+++ b/shell/ev-daemon-gdbus.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Introspection 0.1//EN"
+                      "http://www.freedesktop.org/software/dbus/introspection.dtd">
+<node>
+  <interface name="org.x.reader.Daemon">
+    <method name="RegisterDocument">
+      <arg type="s" name="uri" direction="in"/>
+      <arg type="s" name="owner" direction="out"/>
+    </method>
+    <method name="UnregisterDocument">
+      <arg type="s" name="uri" direction="in"/>
+    </method>
+    <method name="FindDocument">
+      <arg type="s" name="uri" direction="in"/>
+      <arg type="b" name="spawn" direction="in"/>
+      <arg type="s" name="owner" direction="out"/>
+    </method>
+  </interface>
+</node>

--- a/shell/ev-daemon.c
+++ b/shell/ev-daemon.c
@@ -31,6 +31,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "ev-daemon-gdbus-generated.h"
+
 #define EV_DBUS_DAEMON_NAME             "org.x.reader.Daemon"
 #define EV_DBUS_DAEMON_INTERFACE_NAME   "org.x.reader.Daemon"
 #define EV_DBUS_DAEMON_OBJECT_PATH      "/org/x/reader/Daemon"
@@ -210,162 +212,145 @@ document_loaded_cb (GDBusConnection *connection,
 	g_dbus_connection_signal_unsubscribe (connection, doc->loaded_id);
 }
 
-static void
-method_call_cb (GDBusConnection       *connection,
-                const gchar           *sender,
-                const gchar           *object_path,
-                const gchar           *interface_name,
-                const gchar           *method_name,
-                GVariant              *parameters,
-                GDBusMethodInvocation *invocation,
-                gpointer               user_data)
+static gboolean
+handle_register_document_cb (EvDaemon *object,
+                             GDBusMethodInvocation *invocation,
+                             const gchar *uri,
+                             gpointer user_data)
 {
-        if (g_strcmp0 (interface_name, EV_DBUS_DAEMON_INTERFACE_NAME) != 0)
-                return;
+    GDBusConnection *connection;
+    const char *sender;
+    EvDoc       *doc;
 
-        if (g_strcmp0 (method_name, "RegisterDocument") == 0) {
-                EvDoc       *doc;
-                const gchar *uri;
+    doc = ev_daemon_find_doc (uri);
+    if (doc != NULL) {
+        LOG ("RegisterDocument found owner '%s' for URI '%s'\n", doc->dbus_name, uri);
+        ev_daemon_complete_register_document (object, invocation, doc->dbus_name);
 
-                g_variant_get (parameters, "(&s)", &uri);
+        return TRUE;
+    }
 
-                doc = ev_daemon_find_doc (uri);
-                if (doc != NULL) {
-                        LOG ("RegisterDocument found owner '%s' for URI '%s'\n", doc->dbus_name, uri);
-                        g_dbus_method_invocation_return_value (invocation,
-                                                               g_variant_new ("(s)", doc->dbus_name));
-                        return;
-                }
+    ev_daemon_stop_killtimer ();
 
-                ev_daemon_stop_killtimer ();
+    sender = g_dbus_method_invocation_get_sender (invocation);
+    connection = g_dbus_method_invocation_get_connection (invocation);
 
-                doc = g_new (EvDoc, 1);
-                doc->dbus_name = g_strdup (sender);
-                doc->uri = g_strdup (uri);
+    doc = g_new (EvDoc, 1);
+    doc->dbus_name = g_strdup (sender);
+    doc->uri = g_strdup (uri);
 
-		doc->loaded_id = g_dbus_connection_signal_subscribe (connection,
-								     doc->dbus_name,
-								     EV_DBUS_WINDOW_INTERFACE_NAME,
-								     "DocumentLoaded",
-								     NULL,
-								     NULL,
-								     0,
-								     (GDBusSignalCallback) document_loaded_cb,
-								     doc,
-								     NULL);
-                doc->watch_id = g_bus_watch_name_on_connection (connection,
-                                                                sender,
-                                                                G_BUS_NAME_WATCHER_FLAGS_NONE,
-                                                                name_appeared_cb,
-                                                                name_vanished_cb,
-                                                                user_data, NULL);
+    doc->loaded_id = g_dbus_connection_signal_subscribe (connection,
+                                                         doc->dbus_name,
+                                                         EV_DBUS_WINDOW_INTERFACE_NAME,
+                                                         "DocumentLoaded",
+                                                         NULL,
+                                                         NULL,
+                                                         0,
+                                                         (GDBusSignalCallback) document_loaded_cb,
+                                                         doc,
+                                                         NULL);
+    doc->watch_id = g_bus_watch_name_on_connection (connection,
+                                                    sender,
+                                                    G_BUS_NAME_WATCHER_FLAGS_NONE,
+                                                    name_appeared_cb,
+                                                    name_vanished_cb,
+                                                    user_data, NULL);
 
-                LOG ("RegisterDocument registered owner '%s' for URI '%s'\n", doc->dbus_name, uri);
-                ev_daemon_docs = g_list_prepend (ev_daemon_docs, doc);
+    LOG ("RegisterDocument registered owner '%s' for URI '%s'\n", doc->dbus_name, uri);
+    ev_daemon_docs = g_list_prepend (ev_daemon_docs, doc);
 
-                g_dbus_method_invocation_return_value (invocation, g_variant_new ("(s)", ""));
-        } else if (g_strcmp0 (method_name, "UnregisterDocument") == 0) {
-                EvDoc *doc;
-                const gchar *uri;
+    ev_daemon_complete_register_document (object, invocation, "");
 
-                g_variant_get (parameters, "(&s)", &uri);
-
-                LOG ("UnregisterDocument URI '%s'\n", uri);
-
-                doc = ev_daemon_find_doc (uri);
-                if (doc == NULL) {
-                        LOG ("UnregisterDocument URI was not registered!\n");
-                        g_dbus_method_invocation_return_error_literal (invocation,
-                                                                       G_DBUS_ERROR,
-                                                                       G_DBUS_ERROR_INVALID_ARGS,
-                                                                       "URI not registered");
-                        return;
-                }
-
-                if (strcmp (doc->dbus_name, sender) != 0) {
-                        LOG ("UnregisterDocument called by non-owner (owner '%s' sender '%s')\n",
-                             doc->dbus_name, sender);
-
-                        g_dbus_method_invocation_return_error_literal (invocation,
-                                                                       G_DBUS_ERROR,
-                                                                       G_DBUS_ERROR_BAD_ADDRESS,
-                                                                       "Only owner can call this method");
-                        return;
-                }
-
-                ev_daemon_docs = g_list_remove (ev_daemon_docs, doc);
-                ev_doc_free (doc);
-                ev_daemon_maybe_start_killtimer (user_data);
-
-                g_dbus_method_invocation_return_value (invocation, g_variant_new ("()"));
-	} else if (g_strcmp0 (method_name, "FindDocument") == 0) {
-		EvDoc *doc;
-		const gchar *uri;
-		gboolean spawn;
-
-		g_variant_get (parameters, "(&sb)",  &uri, &spawn);
-
-		LOG ("FindDocument URI '%s' \n", uri);
-
-		doc = ev_daemon_find_doc (uri);
-		if (doc != NULL) {
-			g_dbus_method_invocation_return_value (invocation,
-							       g_variant_new ("(s)", doc->dbus_name));
-			return;
-		}
-
-		if (spawn) {
-			GList *uri_invocations;
-			gboolean ret_val = TRUE;
-
-			uri_invocations = g_hash_table_lookup (pending_invocations, uri);
-
-			if (uri_invocations == NULL) {
-				/* Only spawn once. */
-				ret_val = spawn_xreader (uri);
-			}
-
-			if (ret_val) {
-				/* Only defer DBUS answer if xreader was succesfully spawned */
-				uri_invocations = g_list_prepend (uri_invocations, invocation);
-				g_hash_table_insert (pending_invocations,
-						     g_strdup (uri),
-						     uri_invocations);
-				return;
-			}
-		}
-
-		LOG ("FindDocument URI '%s' was not registered!\n", uri);
-		g_dbus_method_invocation_return_value (invocation,
-						       g_variant_new ("(s)",""));
-	}
+    return TRUE;
 }
 
-static const char introspection_xml[] =
-  "<node>"
-    "<interface name='org.x.reader.Daemon'>"
-      "<method name='RegisterDocument'>"
-        "<arg type='s' name='uri' direction='in'/>"
-        "<arg type='s' name='owner' direction='out'/>"
-      "</method>"
-      "<method name='UnregisterDocument'>"
-        "<arg type='s' name='uri' direction='in'/>"
-      "</method>"
-      "<method name='FindDocument'>"
-        "<arg type='s' name='uri' direction='in'/>"
-        "<arg type='b' name='spawn' direction='in'/>"
-        "<arg type='s' name='owner' direction='out'/>"
-      "</method>"
-    "</interface>"
-  "</node>";
+static gboolean
+handle_unregister_document_cb (EvDaemon *object,
+                               GDBusMethodInvocation *invocation,
+                               const gchar *uri,
+                               gpointer user_data)
+{
+    EvDoc *doc;
+    const char *sender;
 
-static const GDBusInterfaceVTable interface_vtable = {
-  method_call_cb,
-  NULL,
-  NULL
-};
+    LOG ("UnregisterDocument URI '%s'\n", uri);
 
-static GDBusNodeInfo *introspection_data;
+    doc = ev_daemon_find_doc (uri);
+    if (doc == NULL) {
+        LOG ("UnregisterDocument URI was not registered!\n");
+        g_dbus_method_invocation_return_error_literal (invocation,
+                                                       G_DBUS_ERROR,
+                                                       G_DBUS_ERROR_INVALID_ARGS,
+                                                       "URI not registered");
+        return TRUE;
+    }
+
+    sender = g_dbus_method_invocation_get_sender (invocation);
+    if (strcmp (doc->dbus_name, sender) != 0) {
+        LOG ("UnregisterDocument called by non-owner (owner '%s' sender '%s')\n",
+             doc->dbus_name, sender);
+
+        g_dbus_method_invocation_return_error_literal (invocation,
+                                                       G_DBUS_ERROR,
+                                                       G_DBUS_ERROR_BAD_ADDRESS,
+                                                       "Only owner can call this method");
+        return TRUE;
+    }
+
+    ev_daemon_docs = g_list_remove (ev_daemon_docs, doc);
+    ev_doc_free (doc);
+    ev_daemon_maybe_start_killtimer (user_data);
+
+    ev_daemon_complete_unregister_document (object, invocation);
+
+    return TRUE;
+}
+
+static gboolean
+handle_find_document_cb (EvDaemon *object,
+                         GDBusMethodInvocation *invocation,
+                         const gchar *uri,
+                         gboolean spawn,
+                         gpointer user_data)
+{
+    EvDoc *doc;
+
+    LOG ("FindDocument URI '%s' \n", uri);
+
+    doc = ev_daemon_find_doc (uri);
+    if (doc != NULL) {
+        ev_daemon_complete_find_document (object, invocation, doc->dbus_name);
+
+        return TRUE;
+    }
+
+    if (spawn) {
+		GList *uri_invocations;
+		gboolean ret_val = TRUE;
+
+		uri_invocations = g_hash_table_lookup (pending_invocations, uri);
+
+		if (uri_invocations == NULL) {
+	        /* Only spawn once. */
+	        ret_val = spawn_xreader (uri);
+		}
+
+		if (ret_val) {
+	        /* Only defer DBUS answer if evince was succesfully spawned */
+	        uri_invocations = g_list_prepend (uri_invocations, invocation);
+	        g_hash_table_insert (pending_invocations,
+	                             g_strdup (uri),
+	                             uri_invocations);
+	        return TRUE;
+		}
+    }
+
+    LOG ("FindDocument URI '%s' was not registered!\n", uri);
+    // FIXME: shouldn't this return an error then?
+    ev_daemon_complete_find_document (object, invocation, "");
+
+    return TRUE;
+}
 
 static void
 bus_acquired_cb (GDBusConnection *connection,
@@ -373,26 +358,27 @@ bus_acquired_cb (GDBusConnection *connection,
 		 gpointer         user_data)
 {
 	GMainLoop *loop = (GMainLoop *) user_data;
-	guint      registration_id;
+	EvDaemon *skeleton;
 	GError    *error = NULL;
 
-	if (!introspection_data)
-		introspection_data = g_dbus_node_info_new_for_xml (introspection_xml, NULL);
-
-	registration_id = g_dbus_connection_register_object (connection,
-							     EV_DBUS_DAEMON_OBJECT_PATH,
-							     introspection_data->interfaces[0],
-							     &interface_vtable,
-							     g_main_loop_ref (loop),
-							     (GDestroyNotify) g_main_loop_unref,
-							     &error);
-	if (registration_id == 0) {
-		g_printerr ("Failed to register object: %s\n", error->message);
+    skeleton = ev_daemon_skeleton_new ();
+    if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (skeleton),
+                                           connection,
+                                           EV_DBUS_DAEMON_OBJECT_PATH,
+                                           &error)) {
+        g_printerr ("Failed to export object: %s\n", error->message);
 		g_error_free (error);
 
 		if (g_main_loop_is_running (loop))
 			g_main_loop_quit (loop);
 	}
+
+    g_signal_connect (skeleton, "handle-register-document",
+                      G_CALLBACK (handle_register_document_cb), loop);
+    g_signal_connect (skeleton, "handle-unregister-document",
+                      G_CALLBACK (handle_unregister_document_cb), loop);
+    g_signal_connect (skeleton, "handle-find-document",
+                      G_CALLBACK (handle_find_document_cb), loop);
 }
 
 static void
@@ -444,8 +430,6 @@ main (gint argc, gchar **argv)
         g_bus_unown_name (owner_id);
 
         g_main_loop_unref (loop);
-	if (introspection_data)
-		g_dbus_node_info_unref (introspection_data);
         g_list_foreach (ev_daemon_docs, (GFunc)ev_doc_free, NULL);
         g_list_free (ev_daemon_docs);
         g_hash_table_destroy (pending_invocations);

--- a/shell/ev-gdbus.xml
+++ b/shell/ev-gdbus.xml
@@ -12,4 +12,21 @@
       <arg type='ao' name='window_list' direction='out'/>
     </method>
   </interface>
+  <interface name='org.x.reader.Window'>
+    <annotation name="org.gtk.GDBus.C.Name" value="XreaderWindow" />
+    <method name='SyncView'>
+      <arg type='s' name='source_file' direction='in'/>
+      <arg type='(ii)' name='source_point' direction='in'/>
+      <arg type='u' name='timestamp' direction='in'/>
+    </method>
+    <signal name='SyncSource'>
+      <arg type='s' name='source_file' direction='out'/>
+      <arg type='(ii)' name='source_point' direction='out'/>
+      <arg type='u' name='timestamp' direction='out'/>
+    </signal>
+    <signal name='Closed'/>
+    <signal name='DocumentLoaded'>
+      <arg type='s' name='uri' direction='out'/>
+    </signal>
+  </interface>
 </node>

--- a/shell/ev-gdbus.xml
+++ b/shell/ev-gdbus.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Introspection 0.1//EN"
+                      "http://www.freedesktop.org/software/dbus/introspection.dtd">
+<node>
+  <interface name='org.x.reader.Application'>
+    <annotation name="org.gtk.GDBus.C.Name" value="XreaderApplication" />
+    <method name='Reload'>
+      <arg type='a{sv}' name='args' direction='in'/>
+      <arg type='u' name='timestamp' direction='in'/>
+    </method>
+    <method name='GetWindowList'>
+      <arg type='ao' name='window_list' direction='out'/>
+    </method>
+  </interface>
+</node>


### PR DESCRIPTION
Use gdbus-codegen to produce client- and server-side wrappers for the following D-Bus interfaces:
- org.x.reader.Application
- org.x.reader.Window
- org.x.reader.Daemon

This is the first PR needed to use EvDocument and EvView libs in the future.