### PR TITLE
Make 100% zoom level be real life size

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -376,17 +376,20 @@ ev_document_misc_invert_pixbuf (GdkPixbuf *pixbuf)
 gdouble
 ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 {
-	gdouble dp, di;
+    gdouble dp, di;
+	  GdkRectangle monitorRect;
 
-	/*diagonal in pixels*/
-	dp = hypot (gdk_screen_get_width (screen), gdk_screen_get_height (screen));
+    /*diagonal in pixels*/
+    gdk_screen_get_monitor_geometry(screen, monitor, &monitorRect);
+    dp = hypot (monitorRect.width, monitorRect.height);
 
-	/*diagonal in inches*/
-	di = hypot (gdk_screen_get_width_mm(screen), gdk_screen_get_height_mm (screen)) / 25.4;
+    /*diagonal in inches*/
+    di = hypot (gdk_screen_get_monitor_width_mm(screen, monitor),
+                gdk_screen_get_monitor_height_mm(screen, monitor)) / 25.4;
 
-	di /= gdk_screen_get_monitor_scale_factor(screen, monitor);
+    di /= gdk_screen_get_monitor_scale_factor(screen, monitor);
 
-	return (dp / di);
+    return (dp / di);
 }
 
 /* Returns a locale specific date and time representation */

--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -377,6 +377,7 @@ gdouble
 ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 {
     gdouble dp, di;
+    gint mmX, mmY;
 	  GdkRectangle monitorRect;
 
     /*diagonal in pixels*/
@@ -384,8 +385,16 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
     dp = hypot (monitorRect.width, monitorRect.height);
 
     /*diagonal in inches*/
-    di = hypot (gdk_screen_get_monitor_width_mm(screen, monitor),
-                gdk_screen_get_monitor_height_mm(screen, monitor)) / 25.4;
+    mmX = gdk_screen_get_monitor_width_mm(screen, monitor);
+    mmY = gdk_screen_get_monitor_height_mm(screen, monitor);
+
+    /* Fallback in cases where devices report their aspect ratio */
+    if (mmX == 160 && (mmY == 90 || mmY == 100) ||
+        mmX == 16  && (mmY == 9  || mmY == 10)) {
+        return 96.0;
+    }
+
+    di = hypot (mmX, mmY) / 25.4;
 
     di /= gdk_screen_get_monitor_scale_factor(screen, monitor);
 

--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -382,7 +382,6 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 
     /*diagonal in pixels*/
     gdk_screen_get_monitor_geometry(screen, monitor, &monitorRect);
-    dp = hypot (monitorRect.width, monitorRect.height);
 
     /*diagonal in inches*/
     mmX = gdk_screen_get_monitor_width_mm(screen, monitor);
@@ -390,12 +389,15 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 
     /* Fallback in cases where devices report their aspect ratio */
     if (mmX == 160 && (mmY == 90 || mmY == 100) ||
-        mmX == 16  && (mmY == 9  || mmY == 10)) {
+        mmX == 16  && (mmY == 9  || mmY == 10)  ||
+        mmX == 0 || mmY == 0 ||
+        monitorRect.width == 0 || monitorRect.height == 0) {
         return 96.0;
     }
 
-    di = hypot (mmX, mmY) / 25.4;
+    dp = hypot (monitorRect.width, monitorRect.height);
 
+    di = hypot (mmX, mmY) / 25.4;
     di /= gdk_screen_get_monitor_scale_factor(screen, monitor);
 
     return (dp / di);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -5653,14 +5653,6 @@ ev_view_zoom_out (EvView *view)
 	ev_view_zoom (view, ZOOM_OUT_FACTOR);
 }
 
-void
-ev_view_zoom_reset (EvView *view)
-{
-  gdouble scale;
-  g_return_if_fail (view->sizing_mode == EV_SIZING_FREE);
-  ev_document_model_set_scale (view->model, 1.0);
-}
-
 static double
 zoom_for_size_fit_width (gdouble doc_width,
 			 gdouble doc_height,

--- a/libview/ev-view.h
+++ b/libview/ev-view.h
@@ -67,7 +67,6 @@ gboolean	ev_view_can_zoom_in       (EvView         *view);
 void		ev_view_zoom_in		  (EvView         *view);
 gboolean        ev_view_can_zoom_out      (EvView         *view);
 void		ev_view_zoom_out	  (EvView         *view);
-void		ev_view_zoom_reset	  (EvView         *view);
 void        ev_view_zoom (EvView  *view,
 						  gdouble  factor);
 

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -140,7 +140,7 @@ ev_previewer_window_zoom_reset (GtkAction         *action,
 			      EvPreviewerWindow *window)
 {
 	ev_document_model_set_sizing_mode (window->model, EV_SIZING_FREE);
-	ev_view_zoom_reset (window->view);
+  ev_document_model_set_scale (window->model, get_screen_dpi (window) / 72.0);
 }
 
 static void
@@ -530,6 +530,8 @@ ev_previewer_window_constructor (GType                  type,
 										 n_construct_properties,
 										 construct_params);
 	window = EV_PREVIEWER_WINDOW (object);
+  gtk_widget_hide(GTK_WIDGET (window));
+  gtk_widget_realize (GTK_WIDGET (window));
 
 	dpi = get_screen_dpi (window);
 	ev_document_model_set_min_scale (window->model, MIN_SCALE * dpi / 72.0);

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -304,7 +304,7 @@ static const GtkActionEntry action_entries[] = {
           N_("Shrink the document"),
           G_CALLBACK (ev_previewer_window_zoom_out) },
         { "ViewZoomReset", GTK_STOCK_ZOOM_100, NULL, "<control>0",
-          N_("Reset zoom to 100\%"),
+          N_("Original size"),
           G_CALLBACK (ev_previewer_window_zoom_reset) },
 #if GTKUNIXPRINT_ENABLED
 	/* translators: Print document currently shown in the Print Preview window */

--- a/shell/ev-application.c
+++ b/shell/ev-application.c
@@ -610,10 +610,12 @@ ev_application_open_uri_in_window (EvApplication  *application,
 
 	/* We need to load uri before showing the window, so
 	   we can restore window size without flickering */
-	ev_window_open_uri (ev_window, uri, dest, mode, search_string);
-
-	if (!gtk_widget_get_realized (GTK_WIDGET (ev_window)))
-		gtk_widget_realize (GTK_WIDGET (ev_window));
+    if (!gtk_widget_get_realized (GTK_WIDGET (ev_window))) {
+        gtk_widget_hide(GTK_WIDGET (ev_window));
+        gtk_widget_realize (GTK_WIDGET (ev_window));
+    }
+    ev_window_open_uri (ev_window, uri, dest, mode, search_string);
+    gtk_widget_show(GTK_WIDGET (ev_window));
 
 #ifdef GDK_WINDOWING_X11
     GdkWindow *gdk_window = gtk_widget_get_window (GTK_WIDGET (ev_window));

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5845,8 +5845,8 @@ static const GtkActionEntry entries[] = {
 
 
         /* View menu */
-        { "ViewZoomReset", "zoom-original-symbolic", N_("_Reset Zoom"), "<control>0",
-          N_("Reset zoom to 100\%"),
+        { "ViewZoomReset", "zoom-original-symbolic", N_("_Original size"), "<control>0",
+          N_("View the document at its original size"),
           G_CALLBACK (ev_window_cmd_view_zoom_reset) },
         { "ViewZoomIn", "zoom-in-symbolic", N_("Zoom _In"), "<control>plus",
           N_("Enlarge the document"),
@@ -6173,7 +6173,7 @@ set_action_properties (GtkActionGroup *action_group)
   
   action = gtk_action_group_get_action (action_group, "ViewZoomReset");
 	/*translators: this is the label for toolbar button*/
-	g_object_set (action, "short_label", _("Reset Zoom"), NULL);
+	g_object_set (action, "short_label", _("Original size"), NULL);
 
 	action = gtk_action_group_get_action (action_group, "ViewBestFit");
 	/*translators: this is the label for toolbar button*/

--- a/xreader.pot
+++ b/xreader.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-12 12:08+0100\n"
+"POT-Creation-Date: 2017-09-17 12:32+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -518,7 +518,7 @@ msgid "Shrink the document"
 msgstr ""
 
 #: ../previewer/ev-previewer-window.c:307 ../shell/ev-window.c:5846
-msgid "Reset zoom to 100%"
+msgid "View the document at its original size"
 msgstr ""
 
 #. translators: Print document currently shown in the Print Preview window
@@ -1439,7 +1439,7 @@ msgstr ""
 
 #. View menu
 #: ../shell/ev-window.c:5845
-msgid "_Reset Zoom"
+msgid "_Original size"
 msgstr ""
 
 #: ../shell/ev-window.c:5848
@@ -1649,7 +1649,7 @@ msgstr ""
 
 #. translators: this is the label for toolbar button
 #: ../shell/ev-window.c:6173
-msgid "Reset Zoom"
+msgid "Original size"
 msgstr ""
 
 #. translators: this is the label for toolbar button


### PR DESCRIPTION
On devices that report their aspect ratio rather than the size, it defaults to 96 dpi.
Also renamed "Reset zoom" to "Original size".