### PR TITLE
BugFix: Recent view

### DIFF
--- a/shell/ev-recent-view.c
+++ b/shell/ev-recent-view.c
@@ -112,7 +112,6 @@ on_item_activated (GtkButton *button,
 {
     gchar *uri = (gchar *) g_object_get_data (G_OBJECT (button), "uri");
     g_signal_emit (ev_recent_view, signals[ITEM_ACTIVATED], 0, uri);
-    g_free (uri);
 }
 
 static void


### PR DESCRIPTION
Fix the following bug:

when you open a document with xreader and you open an empty xreader and try to open twice the first opened document there is a bug where xreader try to open a non-existing document.