### PR TITLE
"sidebar-thumbnails: fix clunky scrolling"

### DIFF
--- a/shell/ev-sidebar-thumbnails.c
+++ b/shell/ev-sidebar-thumbnails.c
@@ -874,9 +874,26 @@ ev_sidebar_thumbnails_use_icon_view (EvSidebarThumbnails *sidebar_thumbnails)
 }
 
 static void
+ev_sidebar_thumbnails_row_changed (GtkTreeModel *model,
+                                   GtkTreePath  *path,
+                                   GtkTreeIter  *iter,
+                                   gpointer      data)
+{
+	guint signal_id;
+
+	signal_id = GPOINTER_TO_UINT (data);
+
+	/* PREVENT GtkIconView "row-changed" handler to be reached, as it will
+	 * perform a full invalidate and relayout of all items, See bug:
+	 * https://bugzilla.gnome.org/show_bug.cgi?id=691448#c9 */
+	g_signal_stop_emission (model, signal_id, 0);
+}
+
+static void
 ev_sidebar_thumbnails_init (EvSidebarThumbnails *ev_sidebar_thumbnails)
 {
 	EvSidebarThumbnailsPrivate *priv;
+	guint signal_id;
 	GtkWidget *toolbar;
 	GtkWidget *toolitem;
 	GtkWidget *button;
@@ -892,6 +909,11 @@ ev_sidebar_thumbnails_init (EvSidebarThumbnails *ev_sidebar_thumbnails)
 					       GDK_TYPE_PIXBUF,
 					       G_TYPE_BOOLEAN,
 					       EV_TYPE_JOB_THUMBNAIL);
+
+	signal_id = g_signal_lookup ("row-changed", GTK_TYPE_TREE_MODEL);
+	g_signal_connect (GTK_TREE_MODEL (priv->list_store), "row-changed",
+			  G_CALLBACK (ev_sidebar_thumbnails_row_changed),
+			  GUINT_TO_POINTER (signal_id));
 
 	priv->swindow = gtk_scrolled_window_new (NULL, NULL);
 
@@ -1079,6 +1101,8 @@ thumbnail_job_completed_callback (EvJobThumbnail      *job,
 			    COLUMN_THUMBNAIL_SET, TRUE,
 			    COLUMN_JOB, NULL,
 			    -1);
+
+	gtk_widget_queue_draw (priv->icon_view);
 }
 
 static void


### PR DESCRIPTION
Backport from Evince: https://github.com/GNOME/evince/commit/8b24be3b5606e9279d1fb50b908efd1e1ef12a7b
Fixed also in Atril: https://github.com/mate-desktop/atril/issues/255