### PR TITLE
Fix some warnings when building xreader 2.0.2

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -39,7 +39,6 @@ create_thumbnail_frame (int        width,
 			gboolean   fill_bg)
 {
 	GdkPixbuf *retval;
-	int i;
 	int width_r, height_r;
 
 	if (source_pixbuf)
@@ -420,22 +419,22 @@ ev_document_misc_invert_pixbuf (GdkPixbuf *pixbuf)
 }
 
 gdouble
-ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
+ev_document_misc_get_screen_dpi (GdkScreen *screen, GdkMonitor *monitor)
 {
     gdouble dp, di;
-    gint mmX, mmY;
-	  GdkRectangle monitorRect;
+    int mmX, mmY;
+    GdkRectangle monitorRect;
 
     /*diagonal in pixels*/
-    gdk_screen_get_monitor_geometry(screen, monitor, &monitorRect);
+    gdk_monitor_get_geometry(monitor, &monitorRect);
 
     /*diagonal in inches*/
-    mmX = gdk_screen_get_monitor_width_mm(screen, monitor);
-    mmY = gdk_screen_get_monitor_height_mm(screen, monitor);
+    mmX = gdk_monitor_get_width_mm(monitor);
+    mmY = gdk_monitor_get_height_mm(monitor);
 
     /* Fallback in cases where devices report their aspect ratio */
-    if (mmX == 160 && (mmY == 90 || mmY == 100) ||
-        mmX == 16  && (mmY == 9  || mmY == 10)  ||
+    if ((mmX == 160 && (mmY == 90 || mmY == 100)) ||
+        (mmX == 16  && (mmY == 9  || mmY == 10))  ||
         mmX == 0 || mmY == 0 ||
         monitorRect.width == 0 || monitorRect.height == 0) {
         return 96.0;
@@ -444,7 +443,7 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
     dp = hypot (monitorRect.width, monitorRect.height);
 
     di = hypot (mmX, mmY) / 25.4;
-    di /= gdk_screen_get_monitor_scale_factor(screen, monitor);
+    di /= gdk_monitor_get_scale_factor(monitor);
 
     return (dp / di);
 }

--- a/libdocument/ev-document-misc.h
+++ b/libdocument/ev-document-misc.h
@@ -29,6 +29,7 @@
 #include <cairo.h>
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdkwayland.h>
 #include <gtk/gtk.h>
 #include "ev-macros.h"
 

--- a/libdocument/ev-document-misc.h
+++ b/libdocument/ev-document-misc.h
@@ -70,7 +70,7 @@ cairo_surface_t *ev_document_misc_surface_rotate_and_scale (cairo_surface_t *sur
 void             ev_document_misc_invert_surface (cairo_surface_t *surface);
 void		 ev_document_misc_invert_pixbuf  (GdkPixbuf       *pixbuf);
 
-gdouble          ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor);
+gdouble          ev_document_misc_get_screen_dpi (GdkScreen *screen, GdkMonitor *monitor);
 
 gchar           *ev_document_misc_format_date (GTime utime);
 

--- a/libview/ev-annotation-window.c
+++ b/libview/ev-annotation-window.c
@@ -97,10 +97,12 @@ static gdouble
 get_screen_dpi (EvAnnotationWindow *window)
 {
 	GdkScreen *screen;
-	gint monitor;
+	GdkDisplay *display;
+	GdkMonitor *monitor;
 
 	screen = gtk_window_get_screen (GTK_WINDOW (window));
-	monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
+	display = gdk_screen_get_display (screen);
+	monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
 	return ev_document_misc_get_screen_dpi (screen, monitor);
 }
 

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -71,10 +71,12 @@ static gdouble
 get_screen_dpi (EvPreviewerWindow *window)
 {
 	GdkScreen *screen;
-	gint monitor;
+	GdkDisplay *display;
+	GdkMonitor *monitor;
 
 	screen = gtk_window_get_screen (GTK_WINDOW (window));
-	monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
+	display = gdk_screen_get_display (screen);
+	monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
 	return ev_document_misc_get_screen_dpi (screen, monitor);
 }
 

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -363,12 +363,14 @@ G_DEFINE_TYPE (EvWindow, ev_window, GTK_TYPE_APPLICATION_WINDOW)
 static gdouble
 get_screen_dpi (EvWindow *window)
 {
-    GdkScreen *screen;
-    gint monitor;
+	GdkScreen *screen;
+	GdkDisplay *display;
+	GdkMonitor *monitor;
 
-    screen = gtk_window_get_screen (GTK_WINDOW (window));
-    monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
-    return ev_document_misc_get_screen_dpi (screen, monitor);
+	screen = gtk_window_get_screen (GTK_WINDOW (window));
+	display = gdk_screen_get_display (screen);
+	monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
+	return ev_document_misc_get_screen_dpi (screen, monitor);
 }
 
 static void


### PR DESCRIPTION
Fixes the following warnings when building xreader 2.0.2:

```
ev-document-misc.c: In function ‘create_thumbnail_frame’:
ev-document-misc.c:42:6: warning: unused variable ‘i’ [-Wunused-variable]
  int i;
      ^

ev-document-misc.c: In function ‘ev_document_misc_get_screen_dpi’:
ev-document-misc.c:430:5: warning: ‘gdk_screen_get_monitor_geometry’ is deprecated: Use 'gdk_monitor_get_geometry' instead [-Wdeprecated-declarations]
     gdk_screen_get_monitor_geometry(screen, monitor, &monitorRect);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

ev-document-misc.c:433:5: warning: ‘gdk_screen_get_monitor_width_mm’ is deprecated: Use 'gdk_monitor_get_width_mm' instead [-Wdeprecated-declarations]
     mmX = gdk_screen_get_monitor_width_mm(screen, monitor);
     ^~~

ev-document-misc.c:434:5: warning: ‘gdk_screen_get_monitor_height_mm’ is deprecated: Use 'gdk_monitor_get_height_mm' instead [-Wdeprecated-declarations]
     mmY = gdk_screen_get_monitor_height_mm(screen, monitor);
     ^~~

ev-document-misc.c:437:20: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
     if (mmX == 160 && (mmY == 90 || mmY == 100) ||
         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~

ev-document-misc.c:447:5: warning: ‘gdk_screen_get_monitor_scale_factor’ is deprecated: Use 'gdk_monitor_get_scale_factor' instead [-Wdeprecated-declarations]
     di /= gdk_screen_get_monitor_scale_factor(screen, monitor);
     ^~

ev-annotation-window.c: In function ‘get_screen_dpi’:
ev-annotation-window.c:103:2: warning: ‘gdk_screen_get_monitor_at_window’ is deprecated: Use 'gdk_display_get_monitor_at_window' instead [-Wdeprecated-declarations]
  monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
  ^~~~~~~
```