### PR TITLE
meson: change 'debug' option to 'enable_debug' to avoid collisions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,7 +114,7 @@ cpp_args = [
     '-DHAVE_CONFIG_H',
 ]
 
-if get_option('debug')
+if get_option('enable_debug')
     c_args += '-DEV_ENABLE_DEBUG'
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -83,7 +83,7 @@ option('deprecated_warnings',
 	value: false,
 	description: 'Show build warnings for deprecations'
 )
-option('debug',
+option('enable_debug',
 	type: 'boolean',
 	value: false,
 	description: 'Show build warnings for deprecations'


### PR DESCRIPTION
In newer versions of meson, 'debug' is a built-in option and so using
it in meson_option.txt will cause the build to fail.