### PR TITLE
Backports atril 1.18.3

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -499,7 +499,7 @@ xml_get_pointer_to_node(xmlChar* parserfor,
                         xmlChar*  attributename,
                         xmlChar* attributevalue )
 {
-    xmlNodePtr topchild,children ;
+    xmlNodePtr topchild;
 
     xmlretval = NULL ;
 
@@ -1330,7 +1330,6 @@ epub_document_get_info(EvDocument *document)
 	gchar* infofile ;
 	xmlNodePtr metanode ;
 	GString* buffer ;
-	gchar* archive_dir = epub_document->tmp_archive_dir;
 
 	GString* containerpath = g_string_new(epub_document->tmp_archive_dir);
 	g_string_append_printf(containerpath,"/META-INF/container.xml");

--- a/cut-n-paste/zoom-control/ephy-zoom-control.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-control.c
@@ -278,10 +278,8 @@ static void
 ephy_zoom_control_class_init (EphyZoomControlClass *klass)
 {
 	GObjectClass *object_class;
-	GtkToolItemClass *tool_item_class;
 
 	object_class = (GObjectClass *)klass;
-	tool_item_class = (GtkToolItemClass *)klass;
 
 	object_class->set_property = ephy_zoom_control_set_property;
 	object_class->get_property = ephy_zoom_control_get_property;

--- a/libview/ev-jobs.c
+++ b/libview/ev-jobs.c
@@ -856,7 +856,7 @@ snapshot_callback(WebKitWebView *webview,
 	ev_document_doc_mutex_unlock ();
 	ev_job_succeeded (EV_JOB(job_thumb));
     
-	gtk_widget_destroy (gtk_widget_get_toplevel (webview));
+	gtk_widget_destroy (gtk_widget_get_toplevel (GTK_WIDGET (webview)));
 }
 
 #endif  /* ENABLE_EPUB */
@@ -889,7 +889,7 @@ webview_load_failed_cb (WebKitWebView  *webview,
 	g_warning ("Error loading data from %s: %s", failing_uri, e->message);
 	ev_job_failed_from_error (EV_JOB(job_thumb), e);
 	
-	gtk_widget_destroy (gtk_widget_get_toplevel (webview));
+	gtk_widget_destroy (gtk_widget_get_toplevel (GTK_WIDGET (webview)));
 	
 	return TRUE;
 }
@@ -940,7 +940,7 @@ ev_job_thumbnail_run (EvJob *job)
 		g_signal_connect (WEBKIT_WEB_VIEW(webview), "load-failed",
 		                  G_CALLBACK(webview_load_failed_cb),
 		                  g_object_ref (job_thumb));
-		webkit_web_view_load_uri (webview, (gchar*) rc->page->backend_page);
+		webkit_web_view_load_uri (WEBKIT_WEB_VIEW(webview), (gchar*) rc->page->backend_page);
 	}
 	else 
 #endif  /* ENABLE_EPUB */

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -280,7 +280,8 @@ copy_job_to_job_info (EvJobRender   *job_render,
 		job_info->selection_points = job_render->selection_points;
 		job_info->selection_region = cairo_region_reference (job_render->selection_region);
 		job_info->selection = cairo_surface_reference (job_render->selection);
-		set_device_scale_on_surface (job_info->selection, job_info->device_scale);
+		if (job_info->selection)
+			set_device_scale_on_surface (job_info->selection, job_info->device_scale);
 		g_assert (job_info->selection_points.x1 >= 0);
 		job_info->points_set = TRUE;
 	}
@@ -1023,7 +1024,8 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 					       old_points,
 					       job_info->selection_style,
 					       &text, &base);
-		set_device_scale_on_surface (job_info->selection, job_info->device_scale);
+		if (job_info->selection)
+			set_device_scale_on_surface (job_info->selection, job_info->device_scale);
 		job_info->selection_points = job_info->target_points;
 		g_object_unref (rc);
 		ev_document_doc_mutex_unlock ();

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -2670,7 +2670,7 @@ ev_view_find_window_child_for_annot (EvView       *view,
 	return NULL;
 }
 
-static EvViewWindowChild *
+static void
 ev_view_remove_window_child_for_annot (EvView       *view,
 				     guint         page,
 				     EvAnnotation *annot)

--- a/shell/ev-sidebar-thumbnails.c
+++ b/shell/ev-sidebar-thumbnails.c
@@ -615,6 +615,14 @@ update_visible_range (EvSidebarThumbnails *sidebar_thumbnails,
 {
 	EvSidebarThumbnailsPrivate *priv = sidebar_thumbnails->priv;
 	int old_start_page, old_end_page;
+	int n_pages_in_visible_range;
+
+	/* Preload before and after current visible scrolling range, the same amount of
+	 * thumbs in it, to help prevent thumbnail creation happening in the user's sight.
+	 * https://bugzilla.gnome.org/show_bug.cgi?id=342110#c15 */
+	n_pages_in_visible_range = (end_page - start_page) + 1;
+	start_page = MAX (0, start_page - n_pages_in_visible_range);
+	end_page = MIN (priv->n_pages - 1, end_page + n_pages_in_visible_range);
 
 	old_start_page = priv->start_page;
 	old_end_page = priv->end_page;

--- a/shell/ev-sidebar-thumbnails.c
+++ b/shell/ev-sidebar-thumbnails.c
@@ -108,8 +108,6 @@ static gboolean     ev_sidebar_thumbnails_support_document (EvSidebarPage       
 							    EvDocument              *document);
 static void         ev_sidebar_thumbnails_page_iface_init  (EvSidebarPageInterface  *iface);
 static const gchar* ev_sidebar_thumbnails_get_label        (EvSidebarPage           *sidebar_page);
-static gboolean     ev_sidebar_thumbnails_event            (GtkWidget               *widget,
-							                                GdkEventScroll          *event);
 static void         thumbnail_job_completed_callback       (EvJobThumbnail          *job,
 							    EvSidebarThumbnails     *sidebar_thumbnails);
 static void         adjustment_changed_cb                  (EvSidebarThumbnails     *sidebar_thumbnails);
@@ -398,7 +396,7 @@ ev_sidebar_thumbnails_set_size (EvSidebarThumbnails *sidebar_thumbnails, gint si
         priv->thumbnail_width = THUMBNAIL_MIN_WIDTH;
 
     if (priv->icon_view)
-        gtk_icon_view_set_item_width (priv->icon_view, priv->thumbnail_width);
+        gtk_icon_view_set_item_width (GTK_ICON_VIEW (priv->icon_view), priv->thumbnail_width);
 
     ev_sidebar_thumbnails_reload (sidebar_thumbnails);
 }
@@ -949,7 +947,7 @@ ev_sidebar_thumbnails_init (EvSidebarThumbnails *ev_sidebar_thumbnails)
 	gtk_widget_show (hbox);
 
 	button = gtk_button_new ();
-	gtk_button_set_relief (button, GTK_RELIEF_NONE);
+	gtk_button_set_relief (GTK_BUTTON (button), GTK_RELIEF_NONE);
 	image = gtk_image_new_from_icon_name ("zoom-out-symbolic", GTK_ICON_SIZE_BUTTON);
 	gtk_container_add (GTK_CONTAINER (button), image);
 	gtk_widget_show (image);
@@ -962,7 +960,7 @@ ev_sidebar_thumbnails_init (EvSidebarThumbnails *ev_sidebar_thumbnails)
 	gtk_widget_show (GTK_WIDGET (button));
 
 	button = gtk_button_new ();
-	gtk_button_set_relief (button, GTK_RELIEF_NONE);
+	gtk_button_set_relief (GTK_BUTTON (button), GTK_RELIEF_NONE);
 	image = gtk_image_new_from_icon_name ("zoom-in-symbolic", GTK_ICON_SIZE_BUTTON);
 	gtk_container_add (GTK_CONTAINER (button), image);
 	gtk_widget_show (image);
@@ -975,7 +973,7 @@ ev_sidebar_thumbnails_init (EvSidebarThumbnails *ev_sidebar_thumbnails)
 	gtk_widget_show (GTK_WIDGET (button));
 
 	button = gtk_button_new ();
-	gtk_button_set_relief (button, GTK_RELIEF_NONE);
+	gtk_button_set_relief (GTK_BUTTON (button), GTK_RELIEF_NONE);
 	image = gtk_image_new_from_icon_name ("zoom-original-symbolic", GTK_ICON_SIZE_BUTTON);
 	gtk_container_add (GTK_CONTAINER (button), image);
 	gtk_widget_show (image);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -484,7 +484,6 @@ ev_window_update_actions (EvWindow *ev_window)
     gboolean has_pages = FALSE;
     gboolean presentation_mode;
     gboolean can_find_in_page = FALSE;
-    EvSizingMode sizing_mode;
 
     if (ev_window->priv->document) {
         page = ev_document_model_get_page (ev_window->priv->model);
@@ -4175,7 +4174,6 @@ static void
 ev_window_update_max_min_scale (EvWindow *window)
 {
     gdouble    dpi;
-    GtkAction *action;
     gdouble    min_width, min_height;
     gdouble    width, height;
     gdouble    max_scale;

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -983,7 +983,7 @@ update_document_mode (EvWindow *window,
     if (mode == EV_DOCUMENT_MODE_PRESENTATION) {
         if (window->priv->document) {
             if (window->priv->document->iswebdocument) {
-                ev_window_warning_message(window,_("Cannot enter presentation mode with ePub documents use fullscreen mode instead."));
+				ev_window_warning_message(window,_("Cannot enter presentation mode with ePub documents, use fullscreen mode instead."));
                 return;
             }
         }


### PR DESCRIPTION
Make thumbnail rendering faster and keep already rendered thumbnails in cache. See commit messages for details.

NB: I skipped most of the commits until 1.18.3, since they are either already present within xreader or not useful for us.

