### PR TITLE
EVINCE BACKPORTS: libview: Reset `pressed_button` when starting Drag …

### DIFF
--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4094,6 +4094,7 @@ ev_view_motion_notify_event (GtkWidget      *widget,
 					                 event->y);
 
 			view->selection_info.in_drag = FALSE;
+			view->pressed_button = -1;
 
 			gtk_target_list_unref (target_list);
 
@@ -4116,6 +4117,7 @@ ev_view_motion_notify_event (GtkWidget      *widget,
 					                 event->y);
 
 			view->image_dnd_info.in_drag = FALSE;
+			view->pressed_button = -1;
 
 			gtk_target_list_unref (target_list);
 


### PR DESCRIPTION
…and Drop

Backported by Peter Moser <pitiz29a@gmail.com>

Fixes #27
Fixes #225
Fixes #291

Taken from:
https://gitlab.gnome.org/GNOME/evince/commit/92828bb797742e04aadbfdd62ba1da36837c37cf

commit 92828bb797742e04aadbfdd62ba1da36837c37cf
Author: Jason Crain <jcrain@src.gnome.org>
Date:   Sat Jul 14 20:50:54 2018 -0500

    libview: Reset `pressed_button` when starting Drag and Drop

    If view->pressed_button is left set, when the Drag and Drop operation
    completes, Evince will act as if it is still in a selection event.