### PR TITLE
Fix for #95 "selecting text does not work"

### DIFF
--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -20,14 +20,17 @@ typedef struct _CacheJobInfo
 	/* Selection data. 
 	 * Selection_points are the coordinates encapsulated in selection.
 	 * target_points is the target selection size. */
-	EvRectangle      selection_points;
 	EvRectangle      target_points;
 	EvSelectionStyle selection_style;
 	gboolean         points_set;
 	
 	cairo_surface_t *selection;
-	cairo_region_t  *selection_region;
 	gdouble          selection_scale;
+	EvRectangle      selection_points;
+
+	cairo_region_t  *selection_region;
+	gdouble          selection_region_scale;
+	EvRectangle      selection_region_points;
 } CacheJobInfo;
 
 struct _EvPixbufCache
@@ -279,12 +282,16 @@ copy_job_to_job_info (EvJobRender   *job_render,
 		}
 
 		job_info->selection_points = job_render->selection_points;
-		job_info->selection_region = cairo_region_reference (job_render->selection_region);
 		job_info->selection = cairo_surface_reference (job_render->selection);
 		if (job_info->selection)
 			set_device_scale_on_surface (job_info->selection, job_info->device_scale);
 		job_info->selection_scale = job_render->scale;
 		g_assert (job_info->selection_points.x1 >= 0);
+
+		job_info->selection_region_points = job_render->selection_points;
+		job_info->selection_region = cairo_region_reference (job_render->selection_region);
+		job_info->selection_region_scale = job_render->scale;
+
 		job_info->points_set = TRUE;
 	}
 
@@ -862,8 +869,19 @@ new_selection_surface_needed (EvPixbufCache *pixbuf_cache,
 	return FALSE;
 }
 
+static gboolean
+new_selection_region_needed (EvPixbufCache *pixbuf_cache,
+			     CacheJobInfo  *job_info,
+			     gint           page,
+			     gfloat         scale)
+{
+	if (job_info->selection_region || job_info->points_set)
+		return job_info->selection_region_scale != scale;
+	return FALSE;
+}
+
 static void
-clear_selection_if_needed (EvPixbufCache *pixbuf_cache,
+clear_selection_surface_if_needed (EvPixbufCache *pixbuf_cache,
 			   CacheJobInfo  *job_info,
 			   gint           page,
 			   gfloat         scale)
@@ -873,6 +891,20 @@ clear_selection_if_needed (EvPixbufCache *pixbuf_cache,
 			cairo_surface_destroy (job_info->selection);
 		job_info->selection = NULL;
 		job_info->selection_points.x1 = -1;
+	}
+}
+
+static void
+clear_selection_region_if_needed (EvPixbufCache *pixbuf_cache,
+                                  CacheJobInfo  *job_info,
+                                  gint           page,
+                                  gfloat         scale)
+{
+	if (new_selection_region_needed (pixbuf_cache, job_info, page, scale)) {
+		if (job_info->selection_region)
+			cairo_region_destroy (job_info->selection_region);
+		job_info->selection_region = NULL;
+		job_info->selection_region_points.x1 = -1;
 	}
 }
 
@@ -939,8 +971,7 @@ ev_pixbuf_cache_style_changed (EvPixbufCache *pixbuf_cache)
 cairo_surface_t *
 ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 				       gint             page,
-				       gfloat           scale,
-				       cairo_region_t **region)
+				       gfloat           scale)
 {
 	CacheJobInfo *job_info;
 
@@ -959,15 +990,12 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 	/* If we have a running job, we just return what we have under the
 	 * assumption that it'll be updated later and we can scale it as need
 	 * be */
-	if (job_info->job && EV_JOB_RENDER (job_info->job)->include_selection) {
-		if (region)
-			*region = job_info->selection_region;
+	if (job_info->job && EV_JOB_RENDER (job_info->job)->include_selection)
 		return job_info->selection;
-	}
 
 	/* Now, lets see if we need to resize the image.  If we do, we clear the
 	 * old one. */
-	clear_selection_if_needed (pixbuf_cache, job_info, page, scale * job_info->device_scale);
+	clear_selection_surface_if_needed (pixbuf_cache, job_info, page, scale * job_info->device_scale);
 
 	/* Finally, we see if the two scales are the same, and get a new pixbuf
 	 * if needed.  We do this synchronously for now.  At some point, we
@@ -993,15 +1021,7 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 		rc = ev_render_context_new (ev_page, 0, scale * job_info->device_scale);
 		g_object_unref (ev_page);
 
-		if (job_info->selection_region)
-			cairo_region_destroy (job_info->selection_region);
-		job_info->selection_region =
-			ev_selection_get_selection_region (EV_SELECTION (pixbuf_cache->document),
-							   rc, job_info->selection_style,
-							   &(job_info->target_points));
-
 		get_selection_colors (EV_VIEW (pixbuf_cache->view), &text, &base);
-
 		ev_selection_render_selection (EV_SELECTION (pixbuf_cache->document),
 					       rc, &(job_info->selection),
 					       &(job_info->target_points),
@@ -1015,9 +1035,62 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 		g_object_unref (rc);
 		ev_document_doc_mutex_unlock ();
 	}
-	if (region)
-		*region = job_info->selection_region;
 	return job_info->selection;
+}
+
+cairo_region_t *
+ev_pixbuf_cache_get_selection_region (EvPixbufCache *pixbuf_cache,
+				      gint           page,
+				      gfloat         scale)
+{
+	CacheJobInfo *job_info;
+
+	/* the document does not implement the selection interface */
+	if (!EV_IS_SELECTION (pixbuf_cache->document))
+		return NULL;
+
+	job_info = find_job_cache (pixbuf_cache, page);
+	if (job_info == NULL)
+		return NULL;
+
+	/* No selection on this page */
+	if (!job_info->points_set)
+		return NULL;
+
+	/* If we have a running job, we just return what we have under the
+	 * assumption that it'll be updated later and we can scale it as need
+	 * be */
+	if (job_info->job && EV_JOB_RENDER (job_info->job)->include_selection)
+		return job_info->selection_region;
+
+	/* Now, lets see if we need to resize the region.  If we do, we clear the
+	 * old one. */
+	clear_selection_region_if_needed (pixbuf_cache, job_info, page, scale);
+
+	/* Finally, we see if the two scales are the same, and get a new region
+	 * if needed.
+	 */
+	if (ev_rect_cmp (&(job_info->target_points), &(job_info->selection_region_points))) {
+		EvRenderContext *rc;
+		EvPage *ev_page;
+
+		ev_document_doc_mutex_lock ();
+		ev_page = ev_document_get_page (pixbuf_cache->document, page);
+		rc = ev_render_context_new (ev_page, 0, scale);
+		g_object_unref (ev_page);
+
+		if (job_info->selection_region)
+			cairo_region_destroy (job_info->selection_region);
+		job_info->selection_region =
+			ev_selection_get_selection_region (EV_SELECTION (pixbuf_cache->document),
+							   rc, job_info->selection_style,
+							   &(job_info->target_points));
+		job_info->selection_region_points = job_info->target_points;
+		job_info->selection_region_scale = scale;
+		g_object_unref (rc);
+		ev_document_doc_mutex_unlock ();
+	}
+	return job_info->selection_region;
 }
 
 static void

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -27,6 +27,7 @@ typedef struct _CacheJobInfo
 	
 	cairo_surface_t *selection;
 	cairo_region_t  *selection_region;
+	gdouble          selection_scale;
 } CacheJobInfo;
 
 struct _EvPixbufCache
@@ -282,6 +283,7 @@ copy_job_to_job_info (EvJobRender   *job_render,
 		job_info->selection = cairo_surface_reference (job_render->selection);
 		if (job_info->selection)
 			set_device_scale_on_surface (job_info->selection, job_info->device_scale);
+		job_info->selection_scale = job_render->scale;
 		g_assert (job_info->selection_points.x1 >= 0);
 		job_info->points_set = TRUE;
 	}
@@ -626,29 +628,21 @@ ev_pixbuf_cache_clear_job_sizes (EvPixbufCache *pixbuf_cache,
 }
 
 static void
-get_selection_colors (GtkWidget *widget, GdkColor *text, GdkColor *base)
+get_selection_colors (EvView *view, GdkColor *text, GdkColor *base)
 {
-	GtkStyleContext *context = gtk_widget_get_style_context (widget);
-        GtkStateFlags    state = 0;
         GdkRGBA          fg, bg;
 
-        state |= gtk_widget_has_focus (widget) ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_ACTIVE;
+        _ev_view_get_selection_colors (view, &bg, &fg);
 
-        gtk_style_context_save (context);
-
-        gtk_style_context_get_color (context, state, &fg);
         text->pixel = 0;
         text->red = CLAMP ((guint) (fg.red * 65535), 0, 65535);
         text->green = CLAMP ((guint) (fg.green * 65535), 0, 65535);
         text->blue = CLAMP ((guint) (fg.blue * 65535), 0, 65535);
 
-        gtk_style_context_get_background_color (context, state, &bg);
         base->pixel = 0;
         base->red = CLAMP ((guint) (bg.red * 65535), 0, 65535);
         base->green = CLAMP ((guint) (bg.green * 65535), 0, 65535);
         base->blue = CLAMP ((guint) (bg.blue * 65535), 0, 65535);
-
-        gtk_style_context_restore (context);
 }
 
 static void
@@ -677,7 +671,8 @@ add_job (EvPixbufCache  *pixbuf_cache,
 
 	if (new_selection_surface_needed (pixbuf_cache, job_info, page, scale)) {
 		GdkColor text, base;
-		get_selection_colors (pixbuf_cache->view, &text, &base);
+
+		get_selection_colors (EV_VIEW (pixbuf_cache->view), &text, &base);
 		ev_job_render_set_selection_info (EV_JOB_RENDER (job_info->job), 
 						  &(job_info->target_points),
 						  job_info->selection_style,
@@ -862,24 +857,8 @@ new_selection_surface_needed (EvPixbufCache *pixbuf_cache,
 			      gint           page,
 			      gfloat         scale)
 {
-	if (job_info->selection) {
-		gint width, height;
-		gint selection_width, selection_height;
-
-		_get_page_size_for_scale_and_rotation (pixbuf_cache->document,
-						       page, scale, 0,
-						       &width, &height);
-
-		selection_width = cairo_image_surface_get_width (job_info->selection);
-		selection_height = cairo_image_surface_get_height (job_info->selection);
-		
-		if (width != selection_width || height != selection_height)
-			return TRUE;
-	} else {
-		if (job_info->points_set)
-			return TRUE;
-	}
-	
+	if (job_info->selection || job_info->points_set)
+		return job_info->selection_scale != scale;
 	return FALSE;
 }
 
@@ -934,12 +913,14 @@ ev_pixbuf_cache_style_changed (EvPixbufCache *pixbuf_cache)
 		if (job_info->selection) {
 			cairo_surface_destroy (job_info->selection);
 			job_info->selection = NULL;
+			job_info->selection_points.x1 = -1;
 		}
 
 		job_info = pixbuf_cache->next_job + i;
 		if (job_info->selection) {
 			cairo_surface_destroy (job_info->selection);
 			job_info->selection = NULL;
+			job_info->selection_points.x1 = -1;
 		}
 	}
 
@@ -950,6 +931,7 @@ ev_pixbuf_cache_style_changed (EvPixbufCache *pixbuf_cache)
 		if (job_info->selection) {
 			cairo_surface_destroy (job_info->selection);
 			job_info->selection = NULL;
+			job_info->selection_points.x1 = -1;
 		}
 	}
 }
@@ -977,8 +959,11 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 	/* If we have a running job, we just return what we have under the
 	 * assumption that it'll be updated later and we can scale it as need
 	 * be */
-	if (job_info->job && EV_JOB_RENDER (job_info->job)->include_selection)
+	if (job_info->job && EV_JOB_RENDER (job_info->job)->include_selection) {
+		if (region)
+			*region = job_info->selection_region;
 		return job_info->selection;
+	}
 
 	/* Now, lets see if we need to resize the image.  If we do, we clear the
 	 * old one. */
@@ -1001,7 +986,6 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 			g_assert (job_info->selection == NULL);
 			old_points = NULL;
 		} else {
-			g_assert (job_info->selection != NULL);
 			old_points = &(job_info->selection_points);
 		}
 
@@ -1016,7 +1000,7 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 							   rc, job_info->selection_style,
 							   &(job_info->target_points));
 
-		get_selection_colors (pixbuf_cache->view, &text, &base);
+		get_selection_colors (EV_VIEW (pixbuf_cache->view), &text, &base);
 
 		ev_selection_render_selection (EV_SELECTION (pixbuf_cache->document),
 					       rc, &(job_info->selection),
@@ -1027,6 +1011,7 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 		if (job_info->selection)
 			set_device_scale_on_surface (job_info->selection, job_info->device_scale);
 		job_info->selection_points = job_info->target_points;
+		job_info->selection_scale = scale;
 		g_object_unref (rc);
 		ev_document_doc_mutex_unlock ();
 	}

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -1231,7 +1231,7 @@ ev_pixbuf_cache_get_selection_list (EvPixbufCache *pixbuf_cache)
 			selection->rect = pixbuf_cache->prev_job[i].selection_points;
 			if (pixbuf_cache->prev_job[i].selection_region)
 				selection->covered_region = cairo_region_reference (pixbuf_cache->prev_job[i].selection_region);
-			retval = g_list_append (retval, selection);
+			retval = g_list_prepend (retval, selection);
 		}
 		
 		page ++;
@@ -1245,7 +1245,7 @@ ev_pixbuf_cache_get_selection_list (EvPixbufCache *pixbuf_cache)
 			selection->rect = pixbuf_cache->job_list[i].selection_points;
 			if (pixbuf_cache->job_list[i].selection_region)
 				selection->covered_region = cairo_region_reference (pixbuf_cache->job_list[i].selection_region);
-			retval = g_list_append (retval, selection);
+			retval = g_list_prepend (retval, selection);
 		}
 		
 		page ++;
@@ -1261,13 +1261,13 @@ ev_pixbuf_cache_get_selection_list (EvPixbufCache *pixbuf_cache)
 			selection->rect = pixbuf_cache->next_job[i].selection_points;
 			if (pixbuf_cache->next_job[i].selection_region)
 				selection->covered_region = cairo_region_reference (pixbuf_cache->next_job[i].selection_region);
-			retval = g_list_append (retval, selection);
+			retval = g_list_prepend (retval, selection);
 		}
 		
 		page ++;
 	}
 
-	return retval;
+	return g_list_reverse (retval);
 }
 
 void

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -864,9 +864,9 @@ new_selection_surface_needed (EvPixbufCache *pixbuf_cache,
 			      gint           page,
 			      gfloat         scale)
 {
-	if (job_info->selection || job_info->points_set)
+	if (job_info->selection)
 		return job_info->selection_scale != scale;
-	return FALSE;
+	return job_info->points_set;
 }
 
 static gboolean
@@ -875,9 +875,9 @@ new_selection_region_needed (EvPixbufCache *pixbuf_cache,
 			     gint           page,
 			     gfloat         scale)
 {
-	if (job_info->selection_region || job_info->points_set)
+	if (job_info->selection_region)
 		return job_info->selection_region_scale != scale;
-	return FALSE;
+	return job_info->points_set;
 }
 
 static void
@@ -995,7 +995,7 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 
 	/* Now, lets see if we need to resize the image.  If we do, we clear the
 	 * old one. */
-	clear_selection_surface_if_needed (pixbuf_cache, job_info, page, scale * job_info->device_scale);
+	clear_selection_surface_if_needed (pixbuf_cache, job_info, page, scale);
 
 	/* Finally, we see if the two scales are the same, and get a new pixbuf
 	 * if needed.  We do this synchronously for now.  At some point, we
@@ -1031,7 +1031,7 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 		if (job_info->selection)
 			set_device_scale_on_surface (job_info->selection, job_info->device_scale);
 		job_info->selection_points = job_info->target_points;
-		job_info->selection_scale = scale;
+		job_info->selection_scale = scale * job_info->device_scale;
 		g_object_unref (rc);
 		ev_document_doc_mutex_unlock ();
 	}

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -1226,7 +1226,7 @@ ev_pixbuf_cache_get_selection_list (EvPixbufCache *pixbuf_cache)
 		}
 
 		if (pixbuf_cache->prev_job[i].selection_points.x1 != -1) {
-			selection = g_new0 (EvViewSelection, 1);
+			selection = g_slice_new0 (EvViewSelection);
 			selection->page = page;
 			selection->rect = pixbuf_cache->prev_job[i].selection_points;
 			if (pixbuf_cache->prev_job[i].selection_region)
@@ -1240,7 +1240,7 @@ ev_pixbuf_cache_get_selection_list (EvPixbufCache *pixbuf_cache)
 	page = pixbuf_cache->start_page;
 	for (i = 0; i < PAGE_CACHE_LEN (pixbuf_cache); i++) {
 		if (pixbuf_cache->job_list[i].selection_points.x1 != -1) {
-			selection = g_new0 (EvViewSelection, 1);
+			selection = g_slice_new0 (EvViewSelection);
 			selection->page = page;
 			selection->rect = pixbuf_cache->job_list[i].selection_points;
 			if (pixbuf_cache->job_list[i].selection_region)
@@ -1256,7 +1256,7 @@ ev_pixbuf_cache_get_selection_list (EvPixbufCache *pixbuf_cache)
 			break;
 
 		if (pixbuf_cache->next_job[i].selection_points.x1 != -1) {
-			selection = g_new0 (EvViewSelection, 1);
+			selection = g_slice_new0 (EvViewSelection);
 			selection->page = page;
 			selection->rect = pixbuf_cache->next_job[i].selection_points;
 			if (pixbuf_cache->next_job[i].selection_region)

--- a/libview/ev-pixbuf-cache.h
+++ b/libview/ev-pixbuf-cache.h
@@ -78,8 +78,10 @@ void           ev_pixbuf_cache_set_inverted_colors  (EvPixbufCache *pixbuf_cache
 /* Selection */
 cairo_surface_t *ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 							gint             page,
-							gfloat           scale,
-							cairo_region_t **region);
+							gfloat           scale);
+cairo_region_t *ev_pixbuf_cache_get_selection_region (EvPixbufCache *pixbuf_cache,
+						      gint           page,
+						      gfloat         scale);
 void           ev_pixbuf_cache_set_selection_list   (EvPixbufCache *pixbuf_cache,
 						     GList         *selection_list);
 GList         *ev_pixbuf_cache_get_selection_list   (EvPixbufCache *pixbuf_cache);

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -268,6 +268,9 @@ void _ev_view_transform_doc_rect_to_view_rect (EvView       *view,
 					       int           page,
 					       EvRectangle  *doc_rect,
 					       GdkRectangle *view_rect);
+void _ev_view_get_selection_colors (EvView  *view,
+				    GdkRGBA *bg_color,
+				    GdkRGBA *fg_color);
 
 #endif  /* __EV_VIEW_PRIVATE_H__ */
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6380,7 +6380,7 @@ compute_new_selection_rect (EvView       *view,
 			if (gdk_rectangle_intersect (&page_area, &view_rect, &overlap)) {
 				EvViewSelection *selection;
 
-				selection = g_new0 (EvViewSelection, 1);
+				selection = g_slice_new0 (EvViewSelection);
 				selection->page = i;
 				_ev_view_transform_view_rect_to_doc_rect (view, &overlap, &page_area,
 									  &(selection->rect));
@@ -6458,7 +6458,7 @@ compute_new_selection_text (EvView          *view,
 
 		get_doc_page_size (view, i, &width, &height);
 
-		selection = g_new0 (EvViewSelection, 1);
+		selection = g_slice_new0 (EvViewSelection);
 		selection->page = i;
 		selection->style = style;
 		selection->rect.x1 = selection->rect.y1 = 0;
@@ -6511,8 +6511,7 @@ merge_selection_region (EvView *view,
 
 	/* Update the selection */
 	old_list = ev_pixbuf_cache_get_selection_list (view->pixbuf_cache);
-	g_list_foreach (view->selection_info.selections, (GFunc)selection_free, NULL);
-	g_list_free (view->selection_info.selections);
+	g_list_free_full (view->selection_info.selections, (GDestroyNotify)selection_free);
 	view->selection_info.selections = new_list;
 	ev_pixbuf_cache_set_selection_list (view->pixbuf_cache, new_list);
 	g_signal_emit (view, signals[SIGNAL_SELECTION_CHANGED], 0, NULL);
@@ -6629,8 +6628,7 @@ merge_selection_region (EvView *view,
 	}
 
 	/* Free the old list, now that we're done with it. */
-	g_list_foreach (old_list, (GFunc) selection_free, NULL);
-	g_list_free (old_list);
+	g_list_free_full (old_list, (GDestroyNotify)selection_free);
 }
 
 static void
@@ -6655,15 +6653,14 @@ selection_free (EvViewSelection *selection)
 {
 	if (selection->covered_region)
 		cairo_region_destroy (selection->covered_region);
-	g_free (selection);
+	g_slice_free (EvViewSelection, selection);
 }
 
 static void
 clear_selection (EvView *view)
 {
 	if (view->selection_info.selections) {
-		g_list_foreach (view->selection_info.selections, (GFunc)selection_free, NULL);
-		g_list_free (view->selection_info.selections);
+		g_list_free_full (view->selection_info.selections, (GDestroyNotify)selection_free);
 		view->selection_info.selections = NULL;
 
 		g_signal_emit (view, signals[SIGNAL_SELECTION_CHANGED], 0, NULL);
@@ -6692,7 +6689,7 @@ ev_view_select_all (EvView *view)
 
 		get_doc_page_size (view, i, &width, &height);
 
-		selection = g_new0 (EvViewSelection, 1);
+		selection = g_slice_new0 (EvViewSelection);
 		selection->page = i;
 		selection->style = EV_SELECTION_STYLE_GLYPH;
 		selection->rect.x1 = selection->rect.y1 = 0;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6571,11 +6571,10 @@ merge_selection_region (EvView *view,
 		/* Now we figure out what needs redrawing */
 		if (old_sel && new_sel) {
 			if (old_sel->covered_region && new_sel->covered_region) {
-				/* We only want to redraw the areas that have
-				 * changed, so we xor the old and new regions
-				 * and redraw if it's different */
+				/* Anything that was previously or currently selected may
+				 * have changed */
 				region = cairo_region_copy (old_sel->covered_region);
-				cairo_region_xor (region, new_sel->covered_region);
+				cairo_region_union (region, new_sel->covered_region);
 
 				if (cairo_region_is_empty (region)) {
 					cairo_region_destroy (region);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6472,10 +6472,13 @@ compute_new_selection_text (EvView          *view,
 		else
 			point = stop;
 
-		if (i == first)
+		if (i == first) {
 			_ev_view_transform_view_point_to_doc_point (view, point, &page_area,
 								    &selection->rect.x1,
 								    &selection->rect.y1);
+			selection->rect.x1 -= border.left;
+			selection->rect.y1 -= border.top;
+		}
 
 		/* If the selection is contained within just one page,
 		 * make sure we don't write 'start' into both points
@@ -6483,15 +6486,13 @@ compute_new_selection_text (EvView          *view,
 		if (first == last)
 			point = stop;
 
-		if (i == last)
+		if (i == last) {
 			_ev_view_transform_view_point_to_doc_point (view, point, &page_area,
 								    &selection->rect.x2,
 								    &selection->rect.y2);
-
-		selection->rect.x1 -= border.left;
-		selection->rect.y1 -= border.top;
-		selection->rect.x2 -= border.right;
-		selection->rect.y2 -= border.bottom;
+			selection->rect.x2 -= border.right;
+			selection->rect.y2 -= border.bottom;
+		}
 
 		list = g_list_prepend (list, selection);
 	}

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6578,17 +6578,17 @@ merge_selection_region (EvView *view,
 					cairo_region_union (region, new_sel->covered_region);
 				}
 			} else if (old_sel->covered_region) {
-				region = cairo_region_copy (old_sel->covered_region);
+				region = cairo_region_reference (old_sel->covered_region);
 			} else if (new_sel->covered_region) {
-				region = cairo_region_copy (new_sel->covered_region);
+				region = cairo_region_reference (new_sel->covered_region);
 			}
 		} else if (old_sel && !new_sel) {
 			if (old_sel->covered_region && !cairo_region_is_empty (old_sel->covered_region)) {
-				region = cairo_region_copy (old_sel->covered_region);
+				region = cairo_region_reference (old_sel->covered_region);
 			}
 		} else if (!old_sel && new_sel) {
 			if (new_sel->covered_region && !cairo_region_is_empty (new_sel->covered_region)) {
-				region = cairo_region_copy (new_sel->covered_region);
+				region = cairo_region_reference (new_sel->covered_region);
 			}
 		} else {
 			g_assert_not_reached ();

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6700,7 +6700,6 @@ ev_view_select_all (EvView *view)
 	}
 
 	merge_selection_region (view, g_list_reverse (selections));
-	gtk_widget_queue_draw (GTK_WIDGET (view));
 }
 
 gboolean

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6488,6 +6488,11 @@ compute_new_selection_text (EvView          *view,
 								    &selection->rect.x2,
 								    &selection->rect.y2);
 
+		selection->rect.x1 -= border.left;
+		selection->rect.y1 -= border.top;
+		selection->rect.x2 -= border.right;
+		selection->rect.y2 -= border.bottom;
+
 		list = g_list_prepend (list, selection);
 	}
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4615,6 +4615,45 @@ draw_surface (cairo_t 	      *cr,
 	cairo_restore (cr);
 }
 
+void
+_ev_view_get_selection_colors (EvView  *view,
+			       GdkRGBA *bg_color,
+			       GdkRGBA *fg_color)
+{
+	GtkWidget       *widget = GTK_WIDGET (view);
+	GtkStateFlags    state;
+	GtkStyleContext *context;
+
+	state = gtk_widget_has_focus (widget) ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_ACTIVE;
+	context = gtk_widget_get_style_context (widget);
+
+	if (bg_color)
+		gtk_style_context_get_background_color (context, state, bg_color);
+
+	if (fg_color)
+		gtk_style_context_get_color (context, state, fg_color);
+}
+
+static void
+draw_selection_region (cairo_t        *cr,
+		       cairo_region_t *region,
+		       GdkRGBA        *color,
+		       gint            x,
+		       gint            y,
+		       gdouble         scale_x,
+		       gdouble         scale_y)
+{
+	cairo_save (cr);
+	cairo_translate (cr, x, y);
+	cairo_scale (cr, scale_x, scale_y);
+	gdk_cairo_region (cr, region);
+	cairo_set_source_rgb (cr, color->red, color->green, color->blue);
+	cairo_set_operator (cr, CAIRO_OPERATOR_MULTIPLY);
+	cairo_set_antialias (cr, CAIRO_ANTIALIAS_NONE);
+	cairo_fill (cr);
+	cairo_restore (cr);
+}
+
 static void
 draw_one_page (EvView       *view,
 	       gint          page,
@@ -4663,6 +4702,7 @@ draw_one_page (EvView       *view,
 		cairo_surface_t *page_surface = NULL;
 		cairo_surface_t *selection_surface = NULL;
 		gint offset_x, offset_y;
+		cairo_region_t *region = NULL;
 
 		page_surface = ev_pixbuf_cache_get_surface (view->pixbuf_cache, page);
 
@@ -4685,20 +4725,29 @@ draw_one_page (EvView       *view,
 		draw_surface (cr, page_surface, overlap.x, overlap.y, offset_x, offset_y, width, height);
 
 		/* Get the selection pixbuf iff we have something to draw */
-		if (find_selection_for_page (view, page) &&
-		    view->selection_mode == EV_VIEW_SELECTION_TEXT) {
-			selection_surface =
-				ev_pixbuf_cache_get_selection_surface (view->pixbuf_cache,
-								       page,
-								       view->scale,
-								       NULL);
-		}
+		if (!find_selection_for_page (view, page))
+			return;
 
-		if (!selection_surface) {
+		selection_surface = ev_pixbuf_cache_get_selection_surface (view->pixbuf_cache,
+									   page,
+									   view->scale,
+									   &region);
+		if (selection_surface) {
+			draw_surface (cr, selection_surface, overlap.x, overlap.y, offset_x, offset_y,
+				      width, height);
 			return;
 		}
-		draw_surface (cr, selection_surface, overlap.x, overlap.y, offset_x, offset_y, width, height);
 
+		if (region) {
+			double scale_x, scale_y;
+			GdkRGBA color;
+
+			scale_x = (gdouble)width / cairo_image_surface_get_width (page_surface);
+			scale_y = (gdouble)height / cairo_image_surface_get_height (page_surface);
+			_ev_view_get_selection_colors (view, &color, NULL);
+			draw_selection_region (cr, region, &color, real_page_area.x, real_page_area.y,
+					       scale_x, scale_y);
+		}
 	}
 }
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6439,6 +6439,10 @@ compute_new_selection_text (EvView          *view,
 		GtkBorder border;
 
 		ev_view_get_page_extents (view, i, &page_area, &border);
+		page_area.x -= border.left;
+		page_area.y -= border.top;
+		page_area.width += border.left + border.right;
+		page_area.height += border.top + border.bottom;
 		if (gdk_rectangle_point_in (&page_area, start) ||
 		    gdk_rectangle_point_in (&page_area, stop)) {
 			if (first == n_pages)
@@ -6466,6 +6470,10 @@ compute_new_selection_text (EvView          *view,
 		selection->rect.y2 = height;
 
 		ev_view_get_page_extents (view, i, &page_area, &border);
+		page_area.x -= border.left;
+		page_area.y -= border.top;
+		page_area.width += border.left + border.right;
+		page_area.height += border.top + border.bottom;
 
 		if (gdk_rectangle_point_in (&page_area, start))
 			point = start;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6476,8 +6476,8 @@ compute_new_selection_text (EvView          *view,
 			_ev_view_transform_view_point_to_doc_point (view, point, &page_area,
 								    &selection->rect.x1,
 								    &selection->rect.y1);
-			selection->rect.x1 -= border.left;
-			selection->rect.y1 -= border.top;
+			selection->rect.x1 = MAX (selection->rect.x1 - border.left, 0);
+			selection->rect.y1 = MAX (selection->rect.y1 - border.top, 0);
 		}
 
 		/* If the selection is contained within just one page,
@@ -6490,8 +6490,8 @@ compute_new_selection_text (EvView          *view,
 			_ev_view_transform_view_point_to_doc_point (view, point, &page_area,
 								    &selection->rect.x2,
 								    &selection->rect.y2);
-			selection->rect.x2 -= border.right;
-			selection->rect.y2 -= border.bottom;
+			selection->rect.x2 = MAX (selection->rect.x2 - border.right, 0);
+			selection->rect.y2 = MAX (selection->rect.y2 - border.bottom, 0);
 		}
 
 		list = g_list_prepend (list, selection);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4743,9 +4743,16 @@ draw_one_page (EvView       *view,
 		if (region) {
 			double scale_x, scale_y;
 			GdkRGBA color;
+			double device_scale_x = 1, device_scale_y = 1;
 
 			scale_x = (gdouble)width / cairo_image_surface_get_width (page_surface);
 			scale_y = (gdouble)height / cairo_image_surface_get_height (page_surface);
+
+			cairo_surface_get_device_scale (page_surface, &device_scale_x, &device_scale_y);
+
+			scale_x *= device_scale_x;
+			scale_y *= device_scale_y;
+
 			_ev_view_get_selection_colors (view, &color, NULL);
 			draw_selection_region (cr, region, &color, real_page_area.x, real_page_area.y,
 					       scale_x, scale_y);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6488,10 +6488,10 @@ compute_new_selection_text (EvView          *view,
 								    &selection->rect.x2,
 								    &selection->rect.y2);
 
-		list = g_list_append (list, selection);
+		list = g_list_prepend (list, selection);
 	}
 
-	return list;
+	return g_list_reverse (list);
 }
 
 /* This function takes the newly calculated list, and figures out which regions
@@ -6694,10 +6694,10 @@ ev_view_select_all (EvView *view)
 		selection->rect.x2 = width;
 		selection->rect.y2 = height;
 
-		selections = g_list_append (selections, selection);
+		selections = g_list_prepend (selections, selection);
 	}
 
-	merge_selection_region (view, selections);
+	merge_selection_region (view, g_list_reverse (selections));
 	gtk_widget_queue_draw (GTK_WIDGET (view));
 }
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4624,14 +4624,19 @@ _ev_view_get_selection_colors (EvView  *view,
 	GtkStateFlags    state;
 	GtkStyleContext *context;
 
-	state = gtk_widget_has_focus (widget) ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_ACTIVE;
 	context = gtk_widget_get_style_context (widget);
+	gtk_style_context_save (context);
+	state = gtk_style_context_get_state (context) |
+		(gtk_widget_has_focus (widget) ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_ACTIVE);
+	gtk_style_context_set_state (context, state);
 
 	if (bg_color)
 		gtk_style_context_get_background_color (context, state, bg_color);
 
 	if (fg_color)
 		gtk_style_context_get_color (context, state, fg_color);
+
+	gtk_style_context_restore (context);
 }
 
 static void

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6576,27 +6576,6 @@ merge_selection_region (EvView *view,
 					 * have changed */
 					region = cairo_region_copy (old_sel->covered_region);
 					cairo_region_union (region, new_sel->covered_region);
-
-					if (cairo_region_is_empty (region)) {
-						cairo_region_destroy (region);
-						region = NULL;
-					} else {
-						gint num_rectangles = cairo_region_num_rectangles (region);
-						GdkRectangle r;
-
-						/* We need to make the damage region a little bigger
-						 * because the edges of the old selection might change
-						 */
-						cairo_region_get_rectangle (region, 0, &r);
-						r.x -= 5;
-						r.width = 5;
-						cairo_region_union_rectangle (region, &r);
-
-						cairo_region_get_rectangle (region, num_rectangles - 1, &r);
-						r.x += r.width;
-						r.width = 5;
-						cairo_region_union_rectangle (region, &r);
-					}
 				}
 			} else if (old_sel->covered_region) {
 				region = cairo_region_copy (old_sel->covered_region);
@@ -6617,15 +6596,34 @@ merge_selection_region (EvView *view,
 
 		/* Redraw the damaged region! */
 		if (region) {
-			GdkRectangle page_area;
-			GtkBorder    border;
+			GdkRectangle    page_area;
+			GtkBorder       border;
+			cairo_region_t *damage_region;
+			gint            i, n_rects;
 
 			ev_view_get_page_extents (view, cur_page, &page_area, &border);
-			cairo_region_translate (region,
-					   page_area.x + border.left - view->scroll_x,
-					   page_area.y + border.top - view->scroll_y);
-			gdk_window_invalidate_region (gtk_widget_get_window (GTK_WIDGET (view)), region, TRUE);
+
+			damage_region = cairo_region_create ();
+			/* Translate the region and grow it 2 pixels because for some zoom levels
+			 * the area actually drawn by cairo is larger than the selected region, due
+			 * to rounding errors or pixel alignment.
+			 */
+			n_rects = cairo_region_num_rectangles (region);
+			for (i = 0; i < n_rects; i++) {
+				cairo_rectangle_int_t rect;
+
+				cairo_region_get_rectangle (region, i, &rect);
+				rect.x += page_area.x + border.left - view->scroll_x - 2;
+				rect.y += page_area.y + border.top - view->scroll_y - 2;
+				rect.width += 4;
+				rect.height += 4;
+				cairo_region_union_rectangle (damage_region, &rect);
+			}
 			cairo_region_destroy (region);
+
+			gdk_window_invalidate_region (gtk_widget_get_window (GTK_WIDGET (view)),
+						      damage_region, TRUE);
+			cairo_region_destroy (damage_region);
 		}
 	}
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -6571,30 +6571,32 @@ merge_selection_region (EvView *view,
 		/* Now we figure out what needs redrawing */
 		if (old_sel && new_sel) {
 			if (old_sel->covered_region && new_sel->covered_region) {
-				/* Anything that was previously or currently selected may
-				 * have changed */
-				region = cairo_region_copy (old_sel->covered_region);
-				cairo_region_union (region, new_sel->covered_region);
+				if (!cairo_region_equal (old_sel->covered_region, new_sel->covered_region)) {
+					/* Anything that was previously or currently selected may
+					 * have changed */
+					region = cairo_region_copy (old_sel->covered_region);
+					cairo_region_union (region, new_sel->covered_region);
 
-				if (cairo_region_is_empty (region)) {
-					cairo_region_destroy (region);
-					region = NULL;
-				} else {
-					gint num_rectangles = cairo_region_num_rectangles (region);
-					GdkRectangle r;
+					if (cairo_region_is_empty (region)) {
+						cairo_region_destroy (region);
+						region = NULL;
+					} else {
+						gint num_rectangles = cairo_region_num_rectangles (region);
+						GdkRectangle r;
 
-					/* We need to make the damage region a little bigger
-					 * because the edges of the old selection might change
-					 */
-					cairo_region_get_rectangle (region, 0, &r);
-					r.x -= 5;
-					r.width = 5;
-					cairo_region_union_rectangle (region, &r);
+						/* We need to make the damage region a little bigger
+						 * because the edges of the old selection might change
+						 */
+						cairo_region_get_rectangle (region, 0, &r);
+						r.x -= 5;
+						r.width = 5;
+						cairo_region_union_rectangle (region, &r);
 
-					cairo_region_get_rectangle (region, num_rectangles - 1, &r);
-					r.x += r.width;
-					r.width = 5;
-					cairo_region_union_rectangle (region, &r);
+						cairo_region_get_rectangle (region, num_rectangles - 1, &r);
+						r.x += r.width;
+						r.width = 5;
+						cairo_region_union_rectangle (region, &r);
+					}
 				}
 			} else if (old_sel->covered_region) {
 				region = cairo_region_copy (old_sel->covered_region);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4730,14 +4730,16 @@ draw_one_page (EvView       *view,
 
 		selection_surface = ev_pixbuf_cache_get_selection_surface (view->pixbuf_cache,
 									   page,
-									   view->scale,
-									   &region);
+									   view->scale);
 		if (selection_surface) {
 			draw_surface (cr, selection_surface, overlap.x, overlap.y, offset_x, offset_y,
 				      width, height);
 			return;
 		}
 
+		region = ev_pixbuf_cache_get_selection_region (view->pixbuf_cache,
+							       page,
+							       view->scale);
 		if (region) {
 			double scale_x, scale_y;
 			GdkRGBA color;
@@ -6539,13 +6541,11 @@ merge_selection_region (EvView *view,
 		/* seed the cache with a new page.  We are going to need the new
 		 * region too. */
 		if (new_sel) {
-			cairo_region_t *tmp_region = NULL;
+			cairo_region_t *tmp_region;
 
-			ev_pixbuf_cache_get_selection_surface (view->pixbuf_cache,
-							       cur_page,
-							       view->scale,
-							       &tmp_region);
-
+			tmp_region = ev_pixbuf_cache_get_selection_region (view->pixbuf_cache,
+									   cur_page,
+									   view->scale);
 			if (tmp_region && !cairo_region_is_empty (tmp_region)) {
 				new_sel->covered_region = cairo_region_reference (tmp_region);
 			}


### PR DESCRIPTION
Fixes #95

Works with PDF files already, but needs some additional work to provide the same functionality for all backends. For the latter, I think another PR is better, because it seems to be much more work, and they still work as before for scale = 1.

**UPDATE** It turns out, that the fix for other backends isn't that complicated overall. The new PR should work for all file types.