### PR TITLE
Make help files optional

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,8 @@ override_dh_auto_configure:
 		-D t1lib=true \
 		-D pixbuf=true \
 		-D comics=true \
-		-D introspection=true
+		-D introspection=true \
+		-D help_files=true
 	# 	--disable-static \
 
 override_dh_strip:

--- a/help/meson.build
+++ b/help/meson.build
@@ -17,17 +17,19 @@ if get_option('docs')
 endif
 
 # help files
-help_sources = [
-    'index.docbook',
-    'legal.xml',
-]
+if get_option('help_files')
+  help_sources = [
+      'index.docbook',
+      'legal.xml',
+  ]
 
-help_media = [
-    'figures/xreader_start_window.png',
-]
+  help_media = [
+      'figures/xreader_start_window.png',
+  ]
 
-gnome.yelp(
-    meson.project_name(),
-    sources: help_sources,
-    media: help_media,
-)
+  gnome.yelp(
+      meson.project_name(),
+      sources: help_sources,
+      media: help_media,
+  )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -83,6 +83,11 @@ option('docs',
     value: false,
     description: 'Build the API references (requires gtk-doc)'
 )
+option('help_files',
+    type: 'boolean',
+    value: false,
+    description: 'Build the help files'
+)
 option('introspection',
 	type: 'boolean',
 	value: false,


### PR DESCRIPTION
This makes building of help files optional to prevent root ownership in the build folder when building and installing without package management