### PR TITLE
libdocument: Return default DPI on failure

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -437,7 +437,7 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, GdkMonitor *monitor)
         (mmX == 16  && (mmY == 9  || mmY == 10))  ||
         mmX == 0 || mmY == 0 ||
         monitorRect.width == 0 || monitorRect.height == 0) {
-        return 96.0;
+        return DEFAULT_DPI;
     }
 
     dp = hypot (monitorRect.width, monitorRect.height);
@@ -446,6 +446,25 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, GdkMonitor *monitor)
     di /= gdk_monitor_get_scale_factor(monitor);
 
     return (dp / di);
+}
+
+
+gdouble
+ev_document_misc_get_screen_dpi_at_window(GtkWindow *window)
+{
+	GdkDisplay *display;
+	GdkScreen *screen;
+	GdkMonitor *monitor;
+	GdkWindow *gwindow = gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window)));
+
+	if (!window || !gwindow) {
+		return DEFAULT_DPI;
+	}
+
+	screen = gtk_window_get_screen (window);
+	display = gdk_screen_get_display (screen);
+	monitor = gdk_display_get_monitor_at_window(display, gwindow);
+	return ev_document_misc_get_screen_dpi (screen, monitor) / gdk_monitor_get_scale_factor (monitor);
 }
 
 /* Returns a locale specific date and time representation */

--- a/libdocument/ev-document-misc.h
+++ b/libdocument/ev-document-misc.h
@@ -33,6 +33,9 @@
 #include <gtk/gtk.h>
 #include "ev-macros.h"
 
+
+#define DEFAULT_DPI 96.0
+
 G_BEGIN_DECLS
 
 EV_DEPRECATED
@@ -72,6 +75,9 @@ void             ev_document_misc_invert_surface (cairo_surface_t *surface);
 void		 ev_document_misc_invert_pixbuf  (GdkPixbuf       *pixbuf);
 
 gdouble          ev_document_misc_get_screen_dpi (GdkScreen *screen, GdkMonitor *monitor);
+
+gdouble ev_document_misc_get_screen_dpi_at_window(GtkWindow *window);
+
 
 gchar           *ev_document_misc_format_date (GTime utime);
 

--- a/libview/ev-annotation-window.c
+++ b/libview/ev-annotation-window.c
@@ -1,5 +1,5 @@
 /* ev-annotation-window.c
- *  this file is part of xreader, a mate document viewer
+ *  this file is part of xreader, a generic document viewer
  *
  * Copyright (C) 2009 Carlos Garcia Campos <carlosgc@gnome.org>
  * Copyright (C) 2007 Iñigo Martinez <inigomartinez@gmail.com>
@@ -96,14 +96,7 @@ send_focus_change (GtkWidget *widget,
 static gdouble
 get_screen_dpi (EvAnnotationWindow *window)
 {
-	GdkScreen *screen;
-	GdkDisplay *display;
-	GdkMonitor *monitor;
-
-	screen = gtk_window_get_screen (GTK_WINDOW (window));
-	display = gdk_screen_get_display (screen);
-	monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
-	return ev_document_misc_get_screen_dpi (screen, monitor);
+	return ev_document_misc_get_screen_dpi_at_window (GTK_WINDOW(window));
 }
 
 static void

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -70,14 +70,7 @@ G_DEFINE_TYPE (EvPreviewerWindow, ev_previewer_window, GTK_TYPE_WINDOW)
 static gdouble
 get_screen_dpi (EvPreviewerWindow *window)
 {
-	GdkScreen *screen;
-	GdkDisplay *display;
-	GdkMonitor *monitor;
-
-	screen = gtk_window_get_screen (GTK_WINDOW (window));
-	display = gdk_screen_get_display (screen);
-	monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
-	return ev_document_misc_get_screen_dpi (screen, monitor);
+	return ev_document_misc_get_screen_dpi_at_window (GTK_WINDOW(window));
 }
 
 #if GTKUNIXPRINT_ENABLED

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -363,14 +363,7 @@ G_DEFINE_TYPE (EvWindow, ev_window, GTK_TYPE_APPLICATION_WINDOW)
 static gdouble
 get_screen_dpi (EvWindow *window)
 {
-    GdkScreen *screen;
-    GdkDisplay *display;
-    GdkMonitor *monitor;
-
-    screen = gtk_window_get_screen (GTK_WINDOW (window));
-    display = gdk_screen_get_display (screen);
-    monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(GTK_WIDGET(GTK_WINDOW(window))));
-    return ev_document_misc_get_screen_dpi (screen, monitor) / gdk_monitor_get_scale_factor (monitor);
+    return ev_document_misc_get_screen_dpi_at_window (GTK_WINDOW(window));
 }
 
 static void

--- a/shell/ev-zoom-action.c
+++ b/shell/ev-zoom-action.c
@@ -100,17 +100,21 @@ ev_zoom_action_set_zoom_level (EvZoomAction *zoom_action,
 static void
 ev_zoom_action_update_zoom_level (EvZoomAction *zoom_action)
 {
-	EvZoomActionPrivate *priv = GET_PRIVATE (zoom_action);
+    EvZoomActionPrivate *priv = GET_PRIVATE (zoom_action);
 
-        float      zoom = ev_document_model_get_scale (priv->model);
-        GdkScreen *screen = gtk_widget_get_screen (GTK_WIDGET (zoom_action));
-        GdkWindow *window = gtk_widget_get_parent_window (GTK_WIDGET (zoom_action));
+    float       zoom = ev_document_model_get_scale (priv->model);
+    GdkScreen  *screen = gtk_widget_get_screen (GTK_WIDGET (zoom_action));
+    GdkWindow  *window = gtk_widget_get_parent_window (GTK_WIDGET (zoom_action));
+
+    if (window) {
         GdkDisplay *display = gdk_screen_get_display (screen);
         GdkMonitor *monitor = gdk_display_get_monitor_at_window (display, window);
 
         zoom *= 72.0 / ev_document_misc_get_screen_dpi (screen, monitor);
         zoom *= gdk_monitor_get_scale_factor (monitor);
-        ev_zoom_action_set_zoom_level (zoom_action, zoom);
+    }
+
+    ev_zoom_action_set_zoom_level (zoom_action, zoom);
 }
 
 static void


### PR DESCRIPTION
To calculate the current screen DPI, we have to retrieve
the GdkWindow of the current handled widget. If that has
not been realized yet, NULL will be returned, which was
not handled correctly. Now, a default DPI value will be
returned on failure.

Fixes #314