### PR TITLE
Fix remaining compile-time warnings

### DIFF
--- a/backend/dvi/mdvi-lib/bitmap.c
+++ b/backend/dvi/mdvi-lib/bitmap.c
@@ -20,6 +20,7 @@
 
 #include <config.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "mdvi.h"
 #include "color.h"

--- a/backend/dvi/mdvi-lib/common.h
+++ b/backend/dvi/mdvi-lib/common.h
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <math.h>
+#include <string.h>
 
 #include "sysdeps.h"
 

--- a/backend/dvi/mdvi-lib/files.c
+++ b/backend/dvi/mdvi-lib/files.c
@@ -19,6 +19,7 @@
 #include <config.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <string.h>
 #include <sys/stat.h>
 
 #include "common.h"

--- a/backend/dvi/mdvi-lib/font.c
+++ b/backend/dvi/mdvi-lib/font.c
@@ -18,6 +18,7 @@
 
 #include <config.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "mdvi.h"
 #include "private.h"

--- a/backend/dvi/mdvi-lib/fontmap.c
+++ b/backend/dvi/mdvi-lib/fontmap.c
@@ -706,7 +706,7 @@ static int	mdvi_init_fontmaps(void)
 	FILE	*in;
 	Dstring	input;
 	int	count = 0;
-	char	*config;
+	const char	*config;
 
 	if(fontmaps_loaded)
 		return 0;

--- a/backend/dvi/mdvi-lib/hash.c
+++ b/backend/dvi/mdvi-lib/hash.c
@@ -17,6 +17,7 @@
  */
 
 #include <config.h>
+#include <string.h>
 #include "mdvi.h"
 
 /* simple hash tables for MDVI */

--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -352,7 +352,7 @@ epub_document_save (EvDocument *document,
 {
     EpubDocument *epub_document = EPUB_DOCUMENT (document);
 
-    gchar *source_uri = g_filename_to_uri (epub_document->archivename, NULL, &error);
+    gchar *source_uri = g_filename_to_uri (epub_document->archivename, NULL, error);
     if (source_uri == NULL)
         return FALSE;
 
@@ -1503,12 +1503,6 @@ add_night_sheet(contentListNode *listdata,gchar *sheet)
     open_xml_document(listdata->value);
 
     set_xml_root_node(NULL);
-    xmlNodePtr head = xml_get_pointer_to_node((xmlChar*)"head",NULL,NULL);
-
-    xmlNodePtr link = xmlNewTextChild(head,NULL,(xmlChar*)"link",NULL);
-    xmlAttrPtr href = xmlNewProp(link,(xmlChar*)"href",(xmlChar*)sheeturi);
-    xmlAttrPtr rel = xmlNewProp(link,(xmlChar*)"rel",(xmlChar*)"alternate stylesheet");
-    xmlAttrPtr class =  xmlNewProp(link,(xmlChar*)"class",(xmlChar*)"night");
 
     xmlSaveFormatFile (listdata->value, xmldocument, 0);
     xml_free_doc();
@@ -1656,7 +1650,6 @@ static void
 epub_document_add_mathJax(gchar* containeruri,gchar* documentdir)
 {
 	gchar *containerfilename= g_filename_from_uri(containeruri,NULL,NULL);
-	const gchar *backenddir = ev_backends_manager_get_backends_dir();
 	GString *mathjaxdir = g_string_new(MATHJAX_DIRECTORY);
 
 	gchar *mathjaxref = g_filename_to_uri(mathjaxdir->str,NULL,NULL);

--- a/shell/eggfindbar.c
+++ b/shell/eggfindbar.c
@@ -287,7 +287,6 @@ egg_find_bar_init (EggFindBar *find_bar)
 {
   EggFindBarPrivate *priv;
   GtkWidget *label;
-  GtkWidget *alignment;
   GtkWidget *box;
   GtkToolItem *item;
   GtkWidget *arrow;

--- a/shell/ev-preferences-dialog.c
+++ b/shell/ev-preferences-dialog.c
@@ -90,7 +90,7 @@ help_button_clicked(GtkButton *button,
                     gpointer   data)
 {
     EvPreferencesDialog *dlg = EV_PREFERENCES_DIALOG(data);
-    ev_window_show_help(GTK_WINDOW(dlg), NULL);
+    ev_window_show_help(EV_WINDOW(dlg), NULL);
 }
 
 static void

--- a/shell/ev-properties-view.c
+++ b/shell/ev-properties-view.c
@@ -358,12 +358,12 @@ ev_properties_view_set_info (EvPropertiesView *properties, const EvDocumentInfo 
 	}
 	if (info->fields_mask & EV_DOCUMENT_INFO_LINEARIZED)
 	{
-		/* nice hack bro */
-		if (info->linearized == 1)
+		/* Sometimes info->linearized is not a string */
+		if (info->linearized == (char *)1)
 		{
 			set_property (properties, GTK_TABLE (table), LINEARIZED_PROPERTY, _("Yes"), &row);
 		}
-		else if (info->linearized == 0)
+		else if (info->linearized == (char *)0)
 		{
 			set_property (properties, GTK_TABLE (table), LINEARIZED_PROPERTY, _("No"), &row);
 		}

--- a/shell/ev-window-title.c
+++ b/shell/ev-window-title.c
@@ -176,6 +176,9 @@ ev_window_title_update (EvWindowTitle *window_title)
 		gtk_window_set_title (window, password_title);
 		g_free (password_title);
 		break;
+	case EV_WINDOW_TITLE_RECENT:
+		/*Nothing to do; keep compiler quiet */
+		break;
 	}
 
 	g_free (title);


### PR DESCRIPTION
Fixes warnings and adds a handy option to meson that makes all warnings fatal. With this option, it's easy to catch warnings and fix them. In addition, I want to make "implicit function calls" an error.

**UPDATE**
This PR is now only about fixing of warnings. The implicit function handling and -Werror flag has been removed.