### PR TITLE
Build: Fail on implicit function declarations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -129,6 +129,7 @@ c_args = [
     '-DBINDIR="@0@"'.format(join_paths(prefix, bindir)),
     '-DEV_BACKENDSDIR="@0@"'.format(join_paths(prefix, libdir, meson.project_name(), binary_major_version, 'backends')),
     '-DXREADERDATADIR="@0@"'.format(join_paths(prefix, datadir, meson.project_name())),
+    '-Werror=implicit-function-declaration'
 ]
 
 cpp_args = [


### PR DESCRIPTION
Add the compiler flag "-Werror=implicit-function-declaration".

This is a serious warning, so better catch problems at compile time