### PR TITLE
EVINCE BACKPORTS: libview: Allow printing to all formats supported by…

### DIFF
--- a/libview/ev-print-operation.c
+++ b/libview/ev-print-operation.c
@@ -1115,6 +1115,28 @@ ev_print_operation_export_begin (EvPrintOperationExport *export)
 					   (GDestroyNotify)export_print_page_idle_finished);	
 }
 
+static EvFileExporterFormat
+get_file_exporter_format (EvFileExporter   *exporter,
+                          GtkPrintSettings *print_settings)
+{
+	const gchar *file_format;
+	EvFileExporterFormat format = EV_FILE_FORMAT_PS;
+
+	file_format = gtk_print_settings_get (print_settings, GTK_PRINT_SETTINGS_OUTPUT_FILE_FORMAT);
+	if (file_format != NULL) {
+		format = g_ascii_strcasecmp (file_format, "pdf") == 0 ?
+			 EV_FILE_FORMAT_PDF : EV_FILE_FORMAT_PS;
+	} else {
+		if (ev_file_exporter_get_capabilities (exporter) &
+		    EV_FILE_EXPORTER_CAN_GENERATE_PDF)
+			format = EV_FILE_FORMAT_PDF;
+		else
+			format = EV_FILE_FORMAT_PS;
+	}
+
+	return format;
+}
+
 static void
 ev_print_operation_export_print_dialog_response_cb (GtkDialog              *dialog,
 						    gint                    response,
@@ -1129,10 +1151,10 @@ ev_print_operation_export_print_dialog_response_cb (GtkDialog              *dial
 	gdouble           height;
 	gint              first_page;
 	gint              last_page;
-	const gchar      *file_format;
 	gchar            *filename;
 	GError           *error = NULL;
 	EvPrintOperation *op = EV_PRINT_OPERATION (export);
+	EvFileExporterFormat  format;
 	
 	if (response != GTK_RESPONSE_OK &&
 	    response != GTK_RESPONSE_APPLY) {
@@ -1153,7 +1175,11 @@ ev_print_operation_export_print_dialog_response_cb (GtkDialog              *dial
 	page_setup = gtk_print_unix_dialog_get_page_setup (GTK_PRINT_UNIX_DIALOG (dialog));
 	ev_print_operation_export_set_default_page_setup (op, page_setup);
 
-	if (!gtk_printer_accepts_ps (export->printer)) {
+	format = get_file_exporter_format (EV_FILE_EXPORTER (op->document),
+					   print_settings);
+
+	if ((format == EV_FILE_FORMAT_PS && !gtk_printer_accepts_ps (export->printer)) ||
+	    (format == EV_FILE_FORMAT_PDF && !gtk_printer_accepts_pdf (export->printer))) {
 		gtk_widget_destroy (GTK_WIDGET (dialog));
 		
 		g_set_error_literal (&export->error,
@@ -1165,9 +1191,7 @@ ev_print_operation_export_print_dialog_response_cb (GtkDialog              *dial
 		return;
 	}
 
-	file_format = gtk_print_settings_get (print_settings, GTK_PRINT_SETTINGS_OUTPUT_FILE_FORMAT);
-	
-	filename = g_strdup_printf ("xreader_print.%s.XXXXXX", file_format != NULL ? file_format : "");
+	filename = g_strdup_printf ("xreader_print.%s.XXXXXX", format == EV_FILE_FORMAT_PDF ? "pdf" : "ps");
 	export->fd = g_file_open_tmp (filename, &export->temp_file, &error);
 	g_free (filename);
 	if (export->fd <= -1) {
@@ -1272,8 +1296,7 @@ ev_print_operation_export_print_dialog_response_cb (GtkDialog              *dial
 
 	get_first_and_last_page (export, &first_page, &last_page);
 
-	export->fc.format = file_format && g_ascii_strcasecmp (file_format, "pdf") == 0 ?
-		EV_FILE_FORMAT_PDF : EV_FILE_FORMAT_PS;
+	export->fc.format = format;
 	export->fc.filename = export->temp_file;
 	export->fc.first_page = MIN (first_page, last_page);
 	export->fc.last_page = MAX (first_page, last_page);


### PR DESCRIPTION
… backend

Backported by Peter Moser <pitiz29a@gmail.com>

Taken from:
https://gitlab.gnome.org/GNOME/evince/commit/b050d1d596df2b3ef49a61d8

commit b050d1d596df2b3ef49a61d894fc89666288af2a
Author: Marek Kasik <mkasik@redhat.com>
Date:   Thu Mar 27 15:40:52 2014 +0100

    libview: Allow printing to all formats supported by backend

    Set output format of EvPrintOperationExport according to the format
    requested by user or by capabilities of used backend if there
    is only 1 choice.

    https://bugzilla.gnome.org/show_bug.cgi?id=724044