### PR TITLE
meson: fix order-only dependencies on generated headers

### DIFF
--- a/libdocument/meson.build
+++ b/libdocument/meson.build
@@ -134,6 +134,12 @@ libdocument = library(
     install: true,
 )
 
+# this is needed so targets that depend on generated headers can do so
+libdocument_dep = declare_dependency(
+    link_with: libdocument,
+    sources: libdoc_enums[1]
+)
+
 install_headers(
     libdocument_headers,
     subdir: libdoc_header_dir,

--- a/libmisc/meson.build
+++ b/libmisc/meson.build
@@ -8,6 +8,7 @@ libmisc_sources = [
 ]
 
 libmisc_deps = [
+    libdocument_dep,
     glib,
     gtk,
 ]
@@ -15,7 +16,7 @@ libmisc_deps = [
 libmisc = static_library(
     'misc',
     libmisc_sources,
-    link_with: [libdocument, libview],
+    link_with: libview,
     include_directories: include_dirs,
     dependencies: libmisc_deps,
 )

--- a/libview/meson.build
+++ b/libview/meson.build
@@ -67,6 +67,7 @@ libview_marshal = gnome.genmarshal(
 )
 
 libview_deps = [
+    libdocument_dep,
     config_h,
     gail,
     glib,
@@ -79,7 +80,6 @@ libview_deps = [
 libview = library(
     'xreaderview',
     libview_sources + libview_private_headers + libdoc_enums + libview_marshal,
-    link_with: [libdocument],
     include_directories: include_dirs,
     dependencies: libview_deps,
     soversion: binary_major_version,

--- a/previewer/meson.build
+++ b/previewer/meson.build
@@ -13,6 +13,7 @@ previewer_sources += gnome.compile_resources(
 )
 
 previewer_deps = [
+    libdocument_dep,
     gio,
     gtk,
     gtk_unix_print
@@ -22,7 +23,7 @@ executable(
     'xreader-previewer',
     previewer_sources,
     dependencies: previewer_deps,
-    link_with: [libdocument, libview, libmisc],
+    link_with: [libview, libmisc],
     include_directories: include_dirs,
     install: true,
 )

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -87,6 +87,7 @@ ev_resources = gnome.compile_resources(
 shell_sources += ev_resources
 
 xreader_deps = [
+    libdocument_dep,
     config_h,
     gio,
     glib,
@@ -134,7 +135,7 @@ endif
 libshell = static_library(
     'shell',
     shell_sources,
-    link_with: [libdocument, libview],
+    link_with: libview,
     link_whole: [libmisc, libtotemscrsaver, libsmclient, libephyzoom],
     dependencies: xreader_deps,
     include_directories: [include_dirs, cnc_includes],
@@ -143,7 +144,7 @@ libshell = static_library(
 executable(
     'xreader',
     'main.c',
-    link_with: [libdocument, libview],
+    link_with: libview,
     link_whole: libshell,
     dependencies: xreader_deps,
     include_directories: [include_dirs, cnc_includes],

--- a/thumbnailer/meson.build
+++ b/thumbnailer/meson.build
@@ -3,6 +3,7 @@ thumbnailer_sources = [
 ]
 
 thumbnailer_deps = [
+    libdocument_dep,
     glib,
     gtk,
 ]
@@ -10,7 +11,6 @@ thumbnailer_deps = [
 executable(
     'xreader-thumbnailer',
     thumbnailer_sources,
-    link_with: [libdocument],
     include_directories: include_dirs,
     dependencies: thumbnailer_deps,
     install: true,


### PR DESCRIPTION
Without this, ninja cannot guarantee that libdocument/ev-document-type-builtins.h is generated before files which will #include it, and builds may fail. Sometimes the build is "accidentally correct"; ninja seems to currently build this successfully due to the way it chooses between multiple valid jobs, but samurai fails.

See:
https://github.com/mesonbuild/meson/issues/5624
https://github.com/mesonbuild/meson/pull/5625