### PR TITLE
Add new text-markup annotation

### DIFF
--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2325,6 +2325,7 @@ pdf_document_forms_form_field_text_set_text (EvDocumentForms *document,
 
 	poppler_form_field_text_set_text (poppler_field, text);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2340,6 +2341,7 @@ pdf_document_forms_form_field_button_set_state (EvDocumentForms *document,
 
 	poppler_form_field_button_set_state (poppler_field, state);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static gboolean
@@ -2421,6 +2423,7 @@ pdf_document_forms_form_field_choice_select_item (EvDocumentForms *document,
 
 	poppler_form_field_choice_select_item (poppler_field, index);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2436,6 +2439,7 @@ pdf_document_forms_form_field_choice_toggle_item (EvDocumentForms *document,
 
 	poppler_form_field_choice_toggle_item (poppler_field, index);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2450,6 +2454,7 @@ pdf_document_forms_form_field_choice_unselect_all (EvDocumentForms *document,
 
 	poppler_form_field_choice_unselect_all (poppler_field);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2465,6 +2470,7 @@ pdf_document_forms_form_field_choice_set_text (EvDocumentForms *document,
 
 	poppler_form_field_choice_set_text (poppler_field, text);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static gchar *
@@ -2926,7 +2932,6 @@ pdf_document_annotations_remove_annotation (EvDocumentAnnotations *document_anno
         PopplerAnnot  *poppler_annot;
         EvMappingList *mapping_list;
         EvMapping     *annot_mapping;
-        GList         *list;
 
         poppler_annot = POPPLER_ANNOT (g_object_get_data (G_OBJECT (annot), "poppler-annot"));
         pdf_document = PDF_DOCUMENT (document_annotations);
@@ -2946,6 +2951,7 @@ pdf_document_annotations_remove_annotation (EvDocumentAnnotations *document_anno
         }
 
         pdf_document->annots_modified = TRUE;
+	    ev_document_set_modified (EV_DOCUMENT (document_annotations), TRUE);
 }
 
 /* FIXME: this could be moved to poppler */
@@ -3155,6 +3161,8 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 		mapping_list = NULL;
 	}
 
+	annot_set_unique_name (annot);
+
 	if (mapping_list) {
 		list = ev_mapping_list_get_list (mapping_list);
 		list = g_list_append (list, annot_mapping);
@@ -3167,6 +3175,7 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 	}
 
 	pdf_document->annots_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document_annotations), TRUE);
 }
 
 /* FIXME: We could probably add this to poppler */
@@ -3389,6 +3398,7 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 	}
 
 	PDF_DOCUMENT (document_annotations)->annots_modified = TRUE;
+	ev_document_set_modified (EV_DOCUMENT (document_annotations), TRUE);
 }
 
 static void

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -3054,7 +3054,7 @@ copy_poppler_annot (PopplerAnnot* src_annot,
 	poppler_annot_set_color (dst_annot, color);
 	g_free (color);
 
-	if (EV_IS_ANNOTATION_MARKUP (src_annot)) {
+	if (POPPLER_IS_ANNOT_MARKUP (src_annot) && POPPLER_IS_ANNOT_MARKUP (dst_annot)) {
 		PopplerAnnotMarkup *src_markup = POPPLER_ANNOT_MARKUP (src_annot);
 		PopplerAnnotMarkup *dst_markup = POPPLER_ANNOT_MARKUP (dst_annot);
 		char               *label;

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2582,6 +2582,30 @@ get_poppler_annot_text_icon (EvAnnotationTextIcon icon)
 	}
 }
 
+static gboolean
+poppler_annot_can_have_popup_window (PopplerAnnot *poppler_annot)
+{
+	switch (poppler_annot_get_annot_type (poppler_annot)) {
+	case POPPLER_ANNOT_TEXT:
+	case POPPLER_ANNOT_LINE:
+	case POPPLER_ANNOT_SQUARE:
+	case POPPLER_ANNOT_CIRCLE:
+	case POPPLER_ANNOT_POLYGON:
+	case POPPLER_ANNOT_POLY_LINE:
+	case POPPLER_ANNOT_HIGHLIGHT:
+	case POPPLER_ANNOT_UNDERLINE:
+	case POPPLER_ANNOT_SQUIGGLY:
+	case POPPLER_ANNOT_STRIKE_OUT:
+	case POPPLER_ANNOT_STAMP:
+	case POPPLER_ANNOT_CARET:
+	case POPPLER_ANNOT_INK:
+	case POPPLER_ANNOT_FILE_ATTACHMENT:
+		return TRUE;
+	default:
+		return FALSE;
+	}
+}
+
 static EvAnnotation *
 ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 			     EvPage       *page)
@@ -2726,7 +2750,7 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 		poppler_annot_color_to_gdk_color (poppler_annot, &color);
 		ev_annotation_set_color (ev_annot, &color);
 
-		if (POPPLER_IS_ANNOT_MARKUP (poppler_annot)) {
+		if (poppler_annot_can_have_popup_window (poppler_annot)) {
 			PopplerAnnotMarkup *markup;
 			gchar *label;
 			gdouble opacity;
@@ -2765,6 +2789,7 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 			g_object_set (ev_annot,
 				      "label", label,
 				      "opacity", opacity,
+				      "can_have_popup", TRUE,
 				      NULL);
 
 			g_free (label);

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2635,6 +2635,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 				g_object_unref (poppler_attachment);
 		}
 			break;
+		case POPPLER_ANNOT_HIGHLIGHT:
+			ev_annot = ev_annotation_text_markup_highlight_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */
@@ -2642,7 +2645,6 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 			case POPPLER_ANNOT_3D:
 			case POPPLER_ANNOT_CARET:
 			case POPPLER_ANNOT_FREE_TEXT:
-			case POPPLER_ANNOT_HIGHLIGHT:
 			case POPPLER_ANNOT_LINE:
 			case POPPLER_ANNOT_SCREEN:
 			case POPPLER_ANNOT_SOUND:

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2325,7 +2325,6 @@ pdf_document_forms_form_field_text_set_text (EvDocumentForms *document,
 
 	poppler_form_field_text_set_text (poppler_field, text);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2341,7 +2340,6 @@ pdf_document_forms_form_field_button_set_state (EvDocumentForms *document,
 
 	poppler_form_field_button_set_state (poppler_field, state);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static gboolean
@@ -2423,7 +2421,6 @@ pdf_document_forms_form_field_choice_select_item (EvDocumentForms *document,
 
 	poppler_form_field_choice_select_item (poppler_field, index);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2439,7 +2436,6 @@ pdf_document_forms_form_field_choice_toggle_item (EvDocumentForms *document,
 
 	poppler_form_field_choice_toggle_item (poppler_field, index);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2454,7 +2450,6 @@ pdf_document_forms_form_field_choice_unselect_all (EvDocumentForms *document,
 
 	poppler_form_field_choice_unselect_all (poppler_field);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static void
@@ -2470,7 +2465,6 @@ pdf_document_forms_form_field_choice_set_text (EvDocumentForms *document,
 
 	poppler_form_field_choice_set_text (poppler_field, text);
 	PDF_DOCUMENT (document)->forms_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document), TRUE);
 }
 
 static gchar *
@@ -2932,6 +2926,7 @@ pdf_document_annotations_remove_annotation (EvDocumentAnnotations *document_anno
         PopplerAnnot  *poppler_annot;
         EvMappingList *mapping_list;
         EvMapping     *annot_mapping;
+        GList         *list;
 
         poppler_annot = POPPLER_ANNOT (g_object_get_data (G_OBJECT (annot), "poppler-annot"));
         pdf_document = PDF_DOCUMENT (document_annotations);
@@ -2951,7 +2946,6 @@ pdf_document_annotations_remove_annotation (EvDocumentAnnotations *document_anno
         }
 
         pdf_document->annots_modified = TRUE;
-	    ev_document_set_modified (EV_DOCUMENT (document_annotations), TRUE);
 }
 
 /* FIXME: this could be moved to poppler */
@@ -3161,8 +3155,6 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 		mapping_list = NULL;
 	}
 
-	annot_set_unique_name (annot);
-
 	if (mapping_list) {
 		list = ev_mapping_list_get_list (mapping_list);
 		list = g_list_append (list, annot_mapping);
@@ -3175,7 +3167,6 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 	}
 
 	pdf_document->annots_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document_annotations), TRUE);
 }
 
 /* FIXME: We could probably add this to poppler */
@@ -3398,7 +3389,6 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 	}
 
 	PDF_DOCUMENT (document_annotations)->annots_modified = TRUE;
-	ev_document_set_modified (EV_DOCUMENT (document_annotations), TRUE);
 }
 
 static void

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -3116,7 +3116,14 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 			poppler_rect.y1 = height - ev_rect.y2;
 			poppler_rect.y2 = height - ev_rect.y1;
 
-			poppler_annot_markup_set_popup (markup, &poppler_rect);
+			if (poppler_annot_markup_has_popup (markup))
+#ifdef HAVE_POPPLER_ANNOT_MARKUP_SET_POPUP_RECTANGLE
+				poppler_annot_markup_set_popup_rectangle (markup, &poppler_rect);
+#else
+			        poppler_annot_markup_set_popup (markup, &poppler_rect);
+#endif
+			else
+				poppler_annot_markup_set_popup (markup, &poppler_rect);
 		}
 		if (mask & EV_ANNOTATIONS_SAVE_POPUP_IS_OPEN)
 			poppler_annot_markup_set_popup_is_open (markup, ev_annotation_markup_get_popup_is_open (ev_markup));

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -3066,8 +3066,20 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 			break;
 		case EV_ANNOTATION_TYPE_TEXT_MARKUP: {
 			GArray *quads;
+			PopplerRectangle bbox;
 
-			quads = get_quads_for_area (poppler_page, &rect, NULL);
+			quads = get_quads_for_area (poppler_page, &rect, &bbox);
+
+			if (bbox.x1 != 0 && bbox.y1 != 0 && bbox.x2 != 0 && bbox.y2 != 0) {
+				poppler_rect.x1 = rect.x1 = bbox.x1;
+				poppler_rect.x2 = rect.x2 = bbox.x2;
+				rect.y1 = height - bbox.y2;
+				rect.y2 = height - bbox.y1;
+				poppler_rect.y1 = bbox.y1;
+				poppler_rect.y2 = bbox.y2;
+
+				ev_annotation_set_area (annot, &rect);
+			}
 
 			switch (ev_annotation_text_markup_get_markup_type (EV_ANNOTATION_TEXT_MARKUP (annot))) {
 				case EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT:

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2668,6 +2668,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 	        case POPPLER_ANNOT_UNDERLINE:
 			ev_annot = ev_annotation_text_markup_underline_new (page);
 			break;
+	        case POPPLER_ANNOT_SQUIGGLY:
+			ev_annot = ev_annotation_text_markup_squiggly_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */
@@ -2677,12 +2680,12 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 			case POPPLER_ANNOT_FREE_TEXT:
 			case POPPLER_ANNOT_LINE:
 			case POPPLER_ANNOT_SCREEN:
+			case POPPLER_ANNOT_MOVIE:
 			case POPPLER_ANNOT_SOUND:
 			case POPPLER_ANNOT_INK:
 			case POPPLER_ANNOT_POLYGON:
 			case POPPLER_ANNOT_CIRCLE:
 			case POPPLER_ANNOT_SQUARE:
-			case POPPLER_ANNOT_SQUIGGLY:
 			case POPPLER_ANNOT_STAMP: {
 				/* FIXME: These annotations are unimplemented, but they were already
 				 * reported with test case.  We add a special
@@ -3180,6 +3183,9 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 				break;
 			case EV_ANNOTATION_TEXT_MARKUP_UNDERLINE:
 				new_annot = poppler_annot_text_markup_new_underline (pdf_document->document, &rect, quads);
+				break;
+			case EV_ANNOTATION_TEXT_MARKUP_SQUIGGLY:
+				new_annot = poppler_annot_text_markup_new_squiggly (pdf_document->document, &rect, quads);
 				break;
 			}
 

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2977,7 +2977,7 @@ get_quads_for_area (PopplerPage      *page,
 	quads = g_array_sized_new (TRUE, TRUE,
 				   sizeof (PopplerQuadrilateral),
 				   n_rects);
-	g_array_set_size (quads, n_rects);
+	g_array_set_size (quads, MAX (1, n_rects));
 
 	for (l = rects, i = 0; i < n_rects; i++, l = l->next) {
 		PopplerRectangle     *r = (PopplerRectangle *) l->data;
@@ -3011,6 +3011,13 @@ get_quads_for_area (PopplerPage      *page,
 			bbox->y2 = max_y;
 	}
 	g_list_free (rects);
+
+	if (n_rects == 0 && bbox) {
+		bbox->x1 = 0;
+		bbox->y1 = 0;
+		bbox->x2 = 0;
+		bbox->y2 = 0;
+	}
 
 	return quads;
 }
@@ -3347,20 +3354,25 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 
 			ev_annotation_get_area (annot, &area);
 			quads = get_quads_for_area (poppler_page, &area, &bbox);
-			if (quads->len > 0) {
-				gdouble height;
+			poppler_annot_text_markup_set_quadrilaterals (text_markup, quads);
+			poppler_annot_set_rectangle (poppler_annot, &bbox);
+			g_array_unref (quads);
 
-				poppler_annot_text_markup_set_quadrilaterals (text_markup, quads);
-				poppler_annot_set_rectangle (poppler_annot, &bbox);
+			if (bbox.x1 != 0 && bbox.y1 != 0 && bbox.x2 != 0 && bbox.y2 != 0) {
+				gdouble height;
 
 				poppler_page_get_size (poppler_page, NULL, &height);
 				area.x1 = bbox.x1;
 				area.x2 = bbox.x2;
 				area.y1 = height - bbox.y2;
 				area.y2 = height - bbox.y1;
-				ev_annotation_set_area (annot, &area);
+			} else {
+				area.x1 = 0;
+				area.x2 = 0;
+				area.y1 = 0;
+				area.y2 = 0;
 			}
-			g_array_unref (quads);
+			ev_annotation_set_area (annot, &area);
 		}
 	}
 

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -3135,6 +3135,23 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 		poppler_annot_set_color (poppler_annot, &color);
 	}
 
+	if (mask & EV_ANNOTATIONS_SAVE_AREA) {
+		EvRectangle      area;
+		PopplerRectangle poppler_rect;
+		EvPage          *page;
+		gdouble          height;
+
+		page = ev_annotation_get_page (annot);
+		poppler_page_get_size (POPPLER_PAGE (page->backend_page), NULL, &height);
+
+		ev_annotation_get_area (annot, &area);
+		poppler_rect.x1 = area.x1;
+		poppler_rect.x2 = area.x2;
+		poppler_rect.y1 = height - area.y2;
+		poppler_rect.y2 = height - area.y1;
+		poppler_annot_set_rectangle (poppler_annot, &poppler_rect);
+	}
+
 	if (EV_IS_ANNOTATION_MARKUP (annot)) {
 		EvAnnotationMarkup *ev_markup = EV_ANNOTATION_MARKUP (annot);
 		PopplerAnnotMarkup *markup = POPPLER_ANNOT_MARKUP (poppler_annot);

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -3000,6 +3000,47 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 	pdf_document->annots_modified = TRUE;
 }
 
+/* FIXME: We could probably add this to poppler */
+static void
+copy_poppler_annot (PopplerAnnot* src_annot,
+		    PopplerAnnot* dst_annot)
+{
+	char         *contents;
+	PopplerColor *color;
+
+	contents = poppler_annot_get_contents (src_annot);
+	poppler_annot_set_contents (dst_annot, contents);
+	g_free (contents);
+
+	poppler_annot_set_flags (dst_annot, poppler_annot_get_flags (src_annot));
+
+	color = poppler_annot_get_color (src_annot);
+	poppler_annot_set_color (dst_annot, color);
+	g_free (color);
+
+	if (EV_IS_ANNOTATION_MARKUP (src_annot)) {
+		PopplerAnnotMarkup *src_markup = POPPLER_ANNOT_MARKUP (src_annot);
+		PopplerAnnotMarkup *dst_markup = POPPLER_ANNOT_MARKUP (dst_annot);
+		char               *label;
+
+		label = poppler_annot_markup_get_label (src_markup);
+		poppler_annot_markup_set_label (dst_markup, label);
+		g_free (label);
+
+		poppler_annot_markup_set_opacity (dst_markup, poppler_annot_markup_get_opacity (src_markup));
+
+		if (poppler_annot_markup_has_popup (src_markup)) {
+			PopplerRectangle popup_rect;
+
+			if (poppler_annot_markup_get_popup_rectangle (src_markup, &popup_rect)) {
+				poppler_annot_markup_set_popup (dst_markup, &popup_rect);
+				poppler_annot_markup_set_popup_is_open (dst_markup, poppler_annot_markup_get_popup_is_open (src_markup));
+			}
+
+		}
+	}
+}
+
 static void
 pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annotations,
 					  EvAnnotation          *annot,
@@ -3051,6 +3092,52 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 
 			icon = ev_annotation_text_get_icon (ev_text);
 			poppler_annot_text_set_icon (text, get_poppler_annot_text_icon (icon));
+		}
+	}
+
+	if (EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
+		EvAnnotationTextMarkup *ev_text_markup = EV_ANNOTATION_TEXT_MARKUP (annot);
+		PopplerAnnotTextMarkup *text_markup = POPPLER_ANNOT_TEXT_MARKUP (poppler_annot);
+
+		if (mask & EV_ANNOTATIONS_SAVE_TEXT_MARKUP_TYPE) {
+			/* In poppler every text markup annotation type is a different class */
+			GArray           *quads;
+			PopplerRectangle  rect;
+			PopplerAnnot     *new_annot = NULL;
+			PdfDocument      *pdf_document;
+			EvPage           *page;
+			PopplerPage      *poppler_page;
+
+			pdf_document = PDF_DOCUMENT (document_annotations);
+
+			quads = poppler_annot_text_markup_get_quadrilaterals (text_markup);
+			poppler_annot_get_rectangle (POPPLER_ANNOT (text_markup), &rect);
+
+			switch (ev_annotation_text_markup_get_markup_type (ev_text_markup)) {
+			case EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT:
+				new_annot = poppler_annot_text_markup_new_highlight (pdf_document->document, &rect, quads);
+				break;
+			case EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT:
+				new_annot = poppler_annot_text_markup_new_strikeout (pdf_document->document, &rect, quads);
+				break;
+			case EV_ANNOTATION_TEXT_MARKUP_UNDERLINE:
+				new_annot = poppler_annot_text_markup_new_underline (pdf_document->document, &rect, quads);
+				break;
+			}
+
+			g_array_unref (quads);
+
+			copy_poppler_annot (poppler_annot, new_annot);
+
+			page = ev_annotation_get_page (annot);
+			poppler_page = POPPLER_PAGE (page->backend_page);
+
+			poppler_page_remove_annot (poppler_page, poppler_annot);
+			poppler_page_add_annot (poppler_page, new_annot);
+			g_object_set_data_full (G_OBJECT (annot),
+						"poppler-annot",
+						new_annot,
+						(GDestroyNotify) g_object_unref);
 		}
 	}
 

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2966,7 +2966,7 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 	annot_mapping->data = annot;
 	g_object_set_data_full (G_OBJECT (annot),
 				"poppler-annot",
-				g_object_ref (poppler_annot),
+				poppler_annot,
 				(GDestroyNotify) g_object_unref);
 
 	if (pdf_document->annots) {

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -3073,10 +3073,8 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 			if (bbox.x1 != 0 && bbox.y1 != 0 && bbox.x2 != 0 && bbox.y2 != 0) {
 				poppler_rect.x1 = rect.x1 = bbox.x1;
 				poppler_rect.x2 = rect.x2 = bbox.x2;
-				rect.y1 = height - bbox.y2;
-				rect.y2 = height - bbox.y1;
-				poppler_rect.y1 = bbox.y1;
-				poppler_rect.y2 = bbox.y2;
+				poppler_rect.y1 = rect.y1 = height - bbox.y2;
+				poppler_rect.y2 = rect.y2 = height - bbox.y1;
 
 				ev_annotation_set_area (annot, &rect);
 			}

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -3100,6 +3100,24 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 			poppler_annot_markup_set_label (markup, ev_annotation_markup_get_label (ev_markup));
 		if (mask & EV_ANNOTATIONS_SAVE_OPACITY)
 			poppler_annot_markup_set_opacity (markup, ev_annotation_markup_get_opacity (ev_markup));
+		if (mask & EV_ANNOTATIONS_SAVE_POPUP_RECT) {
+			EvPage *page;
+			EvRectangle ev_rect;
+			PopplerRectangle poppler_rect;
+			gdouble height;
+
+			page = ev_annotation_get_page (annot);
+			poppler_page_get_size (POPPLER_PAGE (page->backend_page),
+						NULL, &height);
+			ev_annotation_markup_get_rectangle (ev_markup, &ev_rect);
+
+			poppler_rect.x1 = ev_rect.x1;
+			poppler_rect.x2 = ev_rect.x2;
+			poppler_rect.y1 = height - ev_rect.y2;
+			poppler_rect.y2 = height - ev_rect.y1;
+
+			poppler_annot_markup_set_popup (markup, &poppler_rect);
+		}
 		if (mask & EV_ANNOTATIONS_SAVE_POPUP_IS_OPEN)
 			poppler_annot_markup_set_popup_is_open (markup, ev_annotation_markup_get_popup_is_open (ev_markup));
 	}

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2948,6 +2948,73 @@ pdf_document_annotations_remove_annotation (EvDocumentAnnotations *document_anno
         pdf_document->annots_modified = TRUE;
 }
 
+/* FIXME: this could be moved to poppler */
+static GArray *
+get_quads_for_area (PopplerPage      *page,
+		    EvRectangle      *area,
+		    PopplerRectangle *bbox)
+{
+	GList  *rects, *l;
+	guint   n_rects;
+	guint   i;
+	GArray *quads;
+	gdouble height;
+	gdouble max_x, max_y, min_x, min_y;
+
+	if (bbox) {
+		bbox->x1 = G_MAXDOUBLE;
+		bbox->y1 = G_MAXDOUBLE;
+		bbox->x2 = G_MINDOUBLE;
+		bbox->y2 = G_MINDOUBLE;
+	}
+
+	poppler_page_get_size (page, NULL, &height);
+
+	rects = poppler_page_get_selection_region (page, 1.0, POPPLER_SELECTION_GLYPH,
+						   (PopplerRectangle *)area);
+	n_rects = g_list_length (rects);
+
+	quads = g_array_sized_new (TRUE, TRUE,
+				   sizeof (PopplerQuadrilateral),
+				   n_rects);
+	g_array_set_size (quads, n_rects);
+
+	for (l = rects, i = 0; i < n_rects; i++, l = l->next) {
+		PopplerRectangle     *r = (PopplerRectangle *) l->data;
+		PopplerQuadrilateral *quad = &g_array_index (quads, PopplerQuadrilateral, i);
+
+		quad->p1.x = r->x1;
+		quad->p1.y = height - r->y2;
+		quad->p2.x = r->x2;
+		quad->p2.y = height - r->y2;
+		quad->p3.x = r->x1;
+		quad->p3.y = height - r->y1;
+		quad->p4.x = r->x2;
+		quad->p4.y = height - r->y1;
+		poppler_rectangle_free (r);
+
+		if (!bbox)
+			continue;
+
+		max_x = MAX (quad->p1.x, MAX (quad->p2.x, MAX (quad->p3.x, quad->p4.x)));
+		max_y = MAX (quad->p1.y, MAX (quad->p2.y, MAX (quad->p3.y, quad->p4.y)));
+		min_x = MIN (quad->p1.x, MIN (quad->p2.x, MIN (quad->p3.x, quad->p4.x)));
+		min_y = MIN (quad->p1.y, MIN (quad->p2.y, MIN (quad->p3.y, quad->p4.y)));
+
+		if (min_x < bbox->x1)
+			bbox->x1 = min_x;
+		if (min_y < bbox->y1)
+			bbox->y1 = min_y;
+		if (max_x > bbox->x2)
+			bbox->x2 = max_x;
+		if (max_y > bbox->y2)
+			bbox->y2 = max_y;
+	}
+	g_list_free (rects);
+
+	return quads;
+}
+
 static void
 pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotations,
 					 EvAnnotation          *annot,
@@ -2989,6 +3056,21 @@ pdf_document_annotations_add_annotation (EvDocumentAnnotations *document_annotat
 			poppler_annot_text_set_icon (POPPLER_ANNOT_TEXT (poppler_annot),
 						     get_poppler_annot_text_icon (icon));
 			}
+			break;
+		case EV_ANNOTATION_TYPE_TEXT_MARKUP: {
+			GArray *quads;
+
+			quads = get_quads_for_area (poppler_page, &rect, NULL);
+
+			switch (ev_annotation_text_markup_get_markup_type (EV_ANNOTATION_TEXT_MARKUP (annot))) {
+				case EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT:
+					poppler_annot = poppler_annot_text_markup_new_highlight (pdf_document->document, &poppler_rect, quads);
+					break;
+				default:
+					g_assert_not_reached ();
+			}
+			g_array_unref (quads);
+		}
 			break;
 		default:
 			g_assert_not_reached ();
@@ -3135,7 +3217,7 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 		poppler_annot_set_color (poppler_annot, &color);
 	}
 
-	if (mask & EV_ANNOTATIONS_SAVE_AREA) {
+	if (mask & EV_ANNOTATIONS_SAVE_AREA && !EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
 		EvRectangle      area;
 		PopplerRectangle poppler_rect;
 		EvPage          *page;
@@ -3251,6 +3333,34 @@ pdf_document_annotations_save_annotation (EvDocumentAnnotations *document_annota
 						"poppler-annot",
 						new_annot,
 						(GDestroyNotify) g_object_unref);
+		}
+
+		if (mask & EV_ANNOTATIONS_SAVE_AREA) {
+			EvRectangle       area;
+			GArray           *quads;
+			PopplerRectangle  bbox;
+			EvPage           *page;
+			PopplerPage      *poppler_page;
+
+			page = ev_annotation_get_page (annot);
+			poppler_page = POPPLER_PAGE (page->backend_page);
+
+			ev_annotation_get_area (annot, &area);
+			quads = get_quads_for_area (poppler_page, &area, &bbox);
+			if (quads->len > 0) {
+				gdouble height;
+
+				poppler_annot_text_markup_set_quadrilaterals (text_markup, quads);
+				poppler_annot_set_rectangle (poppler_annot, &bbox);
+
+				poppler_page_get_size (poppler_page, NULL, &height);
+				area.x1 = bbox.x1;
+				area.x2 = bbox.x2;
+				area.y1 = height - bbox.y2;
+				area.y2 = height - bbox.y1;
+				ev_annotation_set_area (annot, &area);
+			}
+			g_array_unref (quads);
 		}
 	}
 

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2847,10 +2847,18 @@ pdf_document_annotations_get_annotations (EvDocumentAnnotations *document_annota
 		}
 
 		annot_mapping = g_new (EvMapping, 1);
-		annot_mapping->area.x1 = mapping->area.x1;
-		annot_mapping->area.x2 = mapping->area.x2;
-		annot_mapping->area.y1 = height - mapping->area.y2;
-		annot_mapping->area.y2 = height - mapping->area.y1;
+		if (EV_IS_ANNOTATION_TEXT (ev_annot)) {
+			/* Force 24x24 rectangle */
+			annot_mapping->area.x1 = mapping->area.x1;
+			annot_mapping->area.x2 = annot_mapping->area.x1 + 24;
+			annot_mapping->area.y1 = height - mapping->area.y2;
+			annot_mapping->area.y2 = MIN(height, annot_mapping->area.y1 + 24);
+		} else {
+			annot_mapping->area.x1 = mapping->area.x1;
+			annot_mapping->area.x2 = mapping->area.x2;
+			annot_mapping->area.y1 = height - mapping->area.y2;
+			annot_mapping->area.y2 = height - mapping->area.y1;
+		}
 		annot_mapping->data = ev_annot;
 
 		g_object_set_data_full (G_OBJECT (ev_annot),

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2638,6 +2638,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 		case POPPLER_ANNOT_HIGHLIGHT:
 			ev_annot = ev_annotation_text_markup_highlight_new (page);
 			break;
+	        case POPPLER_ANNOT_STRIKE_OUT:
+			ev_annot = ev_annotation_text_markup_strike_out_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */
@@ -2654,7 +2657,6 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 			case POPPLER_ANNOT_SQUARE:
 			case POPPLER_ANNOT_SQUIGGLY:
 			case POPPLER_ANNOT_STAMP:
-			case POPPLER_ANNOT_STRIKE_OUT:
 			case POPPLER_ANNOT_UNDERLINE: {
 				/* FIXME: These annotations are unimplemented, but they were already
 				 * reported with test case.  We add a special

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2641,6 +2641,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 	        case POPPLER_ANNOT_STRIKE_OUT:
 			ev_annot = ev_annotation_text_markup_strike_out_new (page);
 			break;
+	        case POPPLER_ANNOT_UNDERLINE:
+			ev_annot = ev_annotation_text_markup_underline_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */
@@ -2656,8 +2659,7 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 			case POPPLER_ANNOT_CIRCLE:
 			case POPPLER_ANNOT_SQUARE:
 			case POPPLER_ANNOT_SQUIGGLY:
-			case POPPLER_ANNOT_STAMP:
-			case POPPLER_ANNOT_UNDERLINE: {
+			case POPPLER_ANNOT_STAMP: {
 				/* FIXME: These annotations are unimplemented, but they were already
 				 * reported with test case.  We add a special
 				 * warning to let the user know it is unimplemented, yet we do not

--- a/help/reference/libdocument/libxreaderdocument-sections.txt
+++ b/help/reference/libdocument/libxreaderdocument-sections.txt
@@ -570,6 +570,8 @@ ev_annotation_get_color
 ev_annotation_set_color
 ev_annotation_get_rgba
 ev_annotation_set_rgba
+ev_annotation_get_area
+ev_annotation_set_area
 ev_annotation_markup_get_label
 ev_annotation_markup_set_label
 ev_annotation_markup_get_opacity

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1393,6 +1393,16 @@ ev_annotation_text_markup_underline_new (EvPage *page)
         return annot;
 }
 
+EvAnnotation *
+ev_annotation_text_markup_squiggly_new (EvPage *page)
+{
+        EvAnnotation *annot = EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+                                                           "page", page,
+                                                           "type", EV_ANNOTATION_TEXT_MARKUP_SQUIGGLY,
+                                                           NULL));
+        return annot;
+}
+
 EvAnnotationTextMarkupType
 ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot)
 {

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -35,6 +35,7 @@ struct _EvAnnotation {
 	gchar           *name;
 	gchar           *modified;
 	GdkRGBA          rgba;
+    EvRectangle      area;
 };
 
 struct _EvAnnotationClass {
@@ -89,7 +90,8 @@ enum {
 	PROP_ANNOT_NAME,
 	PROP_ANNOT_MODIFIED,
 	PROP_ANNOT_COLOR,
-    PROP_ANNOT_RGBA
+    PROP_ANNOT_RGBA,
+    PROP_ANNOT_AREA
 };
 
 /* EvAnnotationMarkup */
@@ -170,6 +172,10 @@ static void
 ev_annotation_init (EvAnnotation *annot)
 {
 	annot->type = EV_ANNOTATION_TYPE_UNKNOWN;
+    annot->area.x1 = -1;
+    annot->area.y1 = -1;
+    annot->area.x2 = -1;
+    annot->area.y2 = -1;
 }
 
 static void
@@ -198,6 +204,9 @@ ev_annotation_set_property (GObject      *object,
 		break;
     case PROP_ANNOT_RGBA:
         ev_annotation_set_rgba (annot, g_value_get_boxed (value));
+        break;
+    case PROP_ANNOT_AREA:
+        ev_annotation_set_area (annot, g_value_get_boxed (value));
         break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -231,6 +240,9 @@ ev_annotation_get_property (GObject    *object,
     }
 	case PROP_ANNOT_RGBA:
         g_value_set_boxed (value, &annot->rgba);
+        break;
+    case PROP_ANNOT_AREA:
+        g_value_set_boxed (value, &annot->area);
         break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -306,6 +318,22 @@ ev_annotation_class_init (EvAnnotationClass *klass)
                                                          GDK_TYPE_RGBA,
                                                          G_PARAM_READWRITE |
                                                          G_PARAM_STATIC_STRINGS));
+
+        /**
+         * EvAnnotation:area:
+         *
+         * The area of the page where the annotation is placed.
+         *
+         * Since 2.0.2
+         */
+        g_object_class_install_property (g_object_class,
+                                         PROP_ANNOT_AREA,
+                                         g_param_spec_boxed ("area",
+                                                             "Area",
+                                                             "The area of the page where the annotation is placed",
+                                                             EV_TYPE_RECTANGLE,
+                                                             G_PARAM_READWRITE |
+                                                             G_PARAM_STATIC_STRINGS));
 }
 
 EvAnnotationType
@@ -652,6 +680,57 @@ ev_annotation_set_rgba (EvAnnotation  *annot,
 	g_object_notify (G_OBJECT (annot), "color");
 
     return TRUE;
+}
+
+/**
+ * ev_annotation_set_area:
+ * @annot: an #EvAnnotation
+ * @area: (out): a #EvRectangle to be filled with the annotation area
+ *
+ * Gets the area of @annot.
+ *
+ * Since: 2.0.2
+ */
+void
+ev_annotation_get_area (EvAnnotation *annot,
+                        EvRectangle  *area)
+{
+        g_return_if_fail (EV_IS_ANNOTATION (annot));
+        g_return_if_fail (area != NULL);
+
+        *area = annot->area;
+}
+
+/**
+ * ev_annotation_set_area:
+ * @annot: an #Evannotation
+ * @area: a #EvRectangle
+ *
+ * Set the area of the annotation to @area.
+ *
+ * Returns: %TRUE if the area has been changed, %FALSE otherwise
+ *
+ * Since: 3.18
+ */
+gboolean
+ev_annotation_set_area (EvAnnotation      *annot,
+                        const EvRectangle *area)
+{
+        gboolean was_initial;
+
+        g_return_val_if_fail (EV_IS_ANNOTATION (annot), FALSE);
+        g_return_val_if_fail (area != NULL, FALSE);
+
+        if (ev_rect_cmp ((EvRectangle *)area, &annot->area) == 0)
+                return FALSE;
+
+        was_initial = annot->area.x1 == -1 && annot->area.x2 == -1
+                && annot->area.y1 == -1 && annot->area.y2 == -1;
+        annot->area = *area;
+        if (!was_initial)
+                g_object_notify (G_OBJECT (annot), "area");
+
+        return TRUE;
 }
 
 /* EvAnnotationMarkup */

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -66,9 +66,18 @@ struct _EvAnnotationAttachmentClass {
 	EvAnnotationClass parent_class;
 };
 
-static void ev_annotation_markup_default_init          (EvAnnotationMarkupInterface *iface);
-static void ev_annotation_text_markup_iface_init       (EvAnnotationMarkupInterface *iface);
-static void ev_annotation_attachment_markup_iface_init (EvAnnotationMarkupInterface *iface);
+struct _EvAnnotationTextMarkup {
+	EvAnnotation parent;
+};
+
+struct _EvAnnotationTextMarkupClass {
+	EvAnnotationClass parent_class;
+};
+
+static void ev_annotation_markup_default_init           (EvAnnotationMarkupInterface *iface);
+static void ev_annotation_text_markup_iface_init        (EvAnnotationMarkupInterface *iface);
+static void ev_annotation_attachment_markup_iface_init  (EvAnnotationMarkupInterface *iface);
+static void ev_annotation_text_markup_markup_iface_init (EvAnnotationMarkupInterface *iface);
 
 /* EvAnnotation */
 enum {
@@ -113,6 +122,11 @@ G_DEFINE_TYPE_WITH_CODE (EvAnnotationAttachment, ev_annotation_attachment, EV_TY
 	 {
 		 G_IMPLEMENT_INTERFACE (EV_TYPE_ANNOTATION_MARKUP,
 					ev_annotation_attachment_markup_iface_init);
+	 });
+G_DEFINE_TYPE_WITH_CODE (EvAnnotationTextMarkup, ev_annotation_text_markup, EV_TYPE_ANNOTATION,
+	 {
+		 G_IMPLEMENT_INTERFACE (EV_TYPE_ANNOTATION_MARKUP,
+					ev_annotation_text_markup_markup_iface_init);
 	 });
 
 /* EvAnnotation */
@@ -1216,4 +1230,23 @@ ev_annotation_attachment_set_attachment (EvAnnotationAttachment *annot,
 	g_object_notify (G_OBJECT (annot), "attachment");
 
 	return TRUE;
+}
+
+/* EvAnnotationTextMarkup */
+static void
+ev_annotation_text_markup_init (EvAnnotationTextMarkup *annot)
+{
+}
+
+static void
+ev_annotation_text_markup_class_init (EvAnnotationTextMarkupClass *class)
+{
+	GObjectClass *g_object_class = G_OBJECT_CLASS (class);
+
+	ev_annotation_markup_class_install_properties (g_object_class);
+}
+
+static void
+ev_annotation_text_markup_markup_iface_init (EvAnnotationMarkupInterface *iface)
+{
 }

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1326,3 +1326,21 @@ ev_annotation_text_markup_highlight_new (EvPage *page)
                                                            NULL));
         return annot;
 }
+
+EvAnnotation *
+ev_annotation_text_markup_strike_out_new (EvPage *page)
+{
+        EvAnnotation *annot = EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+                                                           "page", page,
+                                                           "type", EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT,
+                                                           NULL));
+        return annot;
+}
+
+EvAnnotationTextMarkupType
+ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot)
+{
+        g_return_val_if_fail (EV_IS_ANNOTATION_TEXT_MARKUP (annot), EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT);
+
+        return annot->type;
+}

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1354,3 +1354,18 @@ ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot)
 
         return annot->type;
 }
+
+gboolean
+ev_annotation_text_markup_set_markup_type (EvAnnotationTextMarkup    *annot,
+                                           EvAnnotationTextMarkupType markup_type)
+{
+        g_return_val_if_fail (EV_IS_ANNOTATION_TEXT_MARKUP (annot), FALSE);
+
+        if (annot->type == markup_type)
+                return FALSE;
+
+        annot->type = markup_type;
+        g_object_notify (G_OBJECT (annot), "type");
+
+        return TRUE;
+}

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1337,6 +1337,16 @@ ev_annotation_text_markup_strike_out_new (EvPage *page)
         return annot;
 }
 
+EvAnnotation *
+ev_annotation_text_markup_underline_new (EvPage *page)
+{
+        EvAnnotation *annot = EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+                                                           "page", page,
+                                                           "type", EV_ANNOTATION_TEXT_MARKUP_UNDERLINE,
+                                                           NULL));
+        return annot;
+}
+
 EvAnnotationTextMarkupType
 ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot)
 {

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -68,6 +68,8 @@ struct _EvAnnotationAttachmentClass {
 
 struct _EvAnnotationTextMarkup {
 	EvAnnotation parent;
+
+        EvAnnotationTextMarkupType type;
 };
 
 struct _EvAnnotationTextMarkupClass {
@@ -109,6 +111,11 @@ enum {
 /* EvAnnotationAttachment */
 enum {
 	PROP_ATTACHMENT_ATTACHMENT = PROP_MARKUP_POPUP_IS_OPEN + 1
+};
+
+/* EvAnnotationTextMarkup */
+enum {
+        PROP_TEXT_MARKUP_TYPE = PROP_MARKUP_POPUP_IS_OPEN + 1
 };
 
 G_DEFINE_ABSTRACT_TYPE (EvAnnotation, ev_annotation, G_TYPE_OBJECT)
@@ -1234,8 +1241,53 @@ ev_annotation_attachment_set_attachment (EvAnnotationAttachment *annot,
 
 /* EvAnnotationTextMarkup */
 static void
+ev_annotation_text_markup_get_property (GObject    *object,
+                                        guint       prop_id,
+                                        GValue     *value,
+                                        GParamSpec *pspec)
+{
+	EvAnnotationTextMarkup *annot = EV_ANNOTATION_TEXT_MARKUP (object);
+
+	if (prop_id < PROP_TEXT_MARKUP_TYPE) {
+		ev_annotation_markup_get_property (object, prop_id, value, pspec);
+		return;
+	}
+
+	switch (prop_id) {
+	case PROP_TEXT_MARKUP_TYPE:
+		g_value_set_enum (value, annot->type);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+	}
+}
+
+static void
+ev_annotation_text_markup_set_property (GObject      *object,
+                                        guint         prop_id,
+                                        const GValue *value,
+                                        GParamSpec   *pspec)
+{
+	EvAnnotationTextMarkup *annot = EV_ANNOTATION_TEXT_MARKUP (object);
+
+	if (prop_id < PROP_TEXT_MARKUP_TYPE) {
+		ev_annotation_markup_set_property (object, prop_id, value, pspec);
+		return;
+	}
+
+	switch (prop_id) {
+	case PROP_TEXT_MARKUP_TYPE:
+                annot->type = g_value_get_enum (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+	}
+}
+
+static void
 ev_annotation_text_markup_init (EvAnnotationTextMarkup *annot)
 {
+        EV_ANNOTATION (annot)->type = EV_ANNOTATION_TYPE_TEXT_MARKUP;
 }
 
 static void
@@ -1244,6 +1296,20 @@ ev_annotation_text_markup_class_init (EvAnnotationTextMarkupClass *class)
 	GObjectClass *g_object_class = G_OBJECT_CLASS (class);
 
 	ev_annotation_markup_class_install_properties (g_object_class);
+
+        g_object_class->get_property = ev_annotation_text_markup_get_property;
+        g_object_class->set_property = ev_annotation_text_markup_set_property;
+
+        g_object_class_install_property (g_object_class,
+					 PROP_TEXT_MARKUP_TYPE,
+					 g_param_spec_enum ("type",
+							    "Type",
+							    "The text markup annotation type",
+							    EV_TYPE_ANNOTATION_TEXT_MARKUP_TYPE,
+							    EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
+							    G_PARAM_READWRITE |
+                                                            G_PARAM_CONSTRUCT |
+                                                            G_PARAM_STATIC_STRINGS));
 }
 
 static void
@@ -1256,8 +1322,7 @@ ev_annotation_text_markup_highlight_new (EvPage *page)
 {
         EvAnnotation *annot = EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
                                                            "page", page,
+                                                           "type", EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
                                                            NULL));
-        annot->type = EV_ANNOTATION_TYPE_HIGHLIGHT;
-
         return annot;
 }

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1250,3 +1250,14 @@ static void
 ev_annotation_text_markup_markup_iface_init (EvAnnotationMarkupInterface *iface)
 {
 }
+
+EvAnnotation *
+ev_annotation_text_markup_highlight_new (EvPage *page)
+{
+        EvAnnotation *annot = EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+                                                           "page", page,
+                                                           NULL));
+        annot->type = EV_ANNOTATION_TYPE_HIGHLIGHT;
+
+        return annot;
+}

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -134,8 +134,10 @@ gboolean             ev_annotation_set_modified              (EvAnnotation      
                                                               const gchar            *modified);
 gboolean             ev_annotation_set_modified_from_time    (EvAnnotation           *annot,
                                                               GTime                   utime);
+EV_DEPRECATED_FOR(ev_annotaion_get_rgba)
 void                 ev_annotation_get_color                 (EvAnnotation           *annot,
                                                               GdkColor               *color);
+EV_DEPRECATED_FOR(ev_annotaion_set_rgba)
 gboolean             ev_annotation_set_color                 (EvAnnotation           *annot,
                                                               const GdkColor         *color);
 void                 ev_annotation_get_rgba                  (EvAnnotation           *annot,
@@ -151,6 +153,7 @@ gboolean             ev_annotation_markup_set_label          (EvAnnotationMarkup
 gdouble              ev_annotation_markup_get_opacity        (EvAnnotationMarkup     *markup);
 gboolean             ev_annotation_markup_set_opacity        (EvAnnotationMarkup     *markup,
                                                               gdouble                 opacity);
+gboolean             ev_annotation_markup_can_have_popup     (EvAnnotationMarkup     *markup);
 gboolean             ev_annotation_markup_has_popup          (EvAnnotationMarkup     *markup);
 gboolean             ev_annotation_markup_set_has_popup      (EvAnnotationMarkup     *markup,
                                                               gboolean                has_popup);

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -111,7 +111,8 @@ typedef enum {
 } EvAnnotationTextIcon;
 
 typedef enum {
-        EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT
+        EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
+        EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT
 } EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
@@ -179,8 +180,10 @@ gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttach
                                                               EvAttachment           *attachment);
 
 /* EvAnnotationTextMarkup */
-GType                ev_annotation_text_markup_get_type      (void) G_GNUC_CONST;
-EvAnnotation        *ev_annotation_text_markup_highlight_new (EvPage *page);
+GType                      ev_annotation_text_markup_get_type        (void) G_GNUC_CONST;
+EvAnnotation              *ev_annotation_text_markup_highlight_new   (EvPage *page);
+EvAnnotation              *ev_annotation_text_markup_strike_out_new  (EvPage *page);
+EvAnnotationTextMarkupType ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot);
 
 G_END_DECLS
 

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -67,6 +67,14 @@ G_BEGIN_DECLS
 #define EV_IS_ANNOTATION_ATTACHMENT_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE((klass), EV_TYPE_ANNOTATION_ATTACHMENT))
 #define EV_ANNOTATION_ATTACHMENT_GET_CLASS(object) (G_TYPE_INSTANCE_GET_CLASS((object), EV_TYPE_ANNOTATION_ATTACHMENT, EvAnnotationAttachmentClass))
 
+/* EvAnnotationTextMarkup */
+#define EV_TYPE_ANNOTATION_TEXT_MARKUP              (ev_annotation_text_markup_get_type ())
+#define EV_ANNOTATION_TEXT_MARKUP(object)           (G_TYPE_CHECK_INSTANCE_CAST ((object), EV_TYPE_ANNOTATION_TEXT_MARKUP, EvAnnotationTextMarkup))
+#define EV_ANNOTATION_TEXT_MARKUP_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass), EV_TYPE_ANNOTATION_TEXT_MARKUP, EvAnnotationTextMarkupClass))
+#define EV_IS_ANNOTATION_TEXT_MARKUP(object)        (G_TYPE_CHECK_INSTANCE_TYPE ((object), EV_TYPE_ANNOTATION_TEXT_MARKUP))
+#define EV_IS_ANNOTATION_TEXT_MARKUP_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), EV_TYPE_ANNOTATION_TEXT_MARKUP))
+#define EV_ANNOTATION_TEXT_MARKUP_GET_CLASS(object) (G_TYPE_INSTANCE_GET_CLASS ((object), EV_TYPE_ANNOTATION_TEXT_MARKUP, EvAnnotationTextMarkupClass))
+
 typedef struct _EvAnnotation                EvAnnotation;
 typedef struct _EvAnnotationClass           EvAnnotationClass;
 
@@ -78,6 +86,9 @@ typedef struct _EvAnnotationTextClass       EvAnnotationTextClass;
 
 typedef struct _EvAnnotationAttachment      EvAnnotationAttachment;
 typedef struct _EvAnnotationAttachmentClass EvAnnotationAttachmentClass;
+
+typedef struct _EvAnnotationTextMarkup      EvAnnotationTextMarkup;
+typedef struct _EvAnnotationTextMarkupClass EvAnnotationTextMarkupClass;
 
 typedef enum {
     EV_ANNOTATION_TYPE_UNKNOWN,
@@ -161,6 +172,9 @@ EvAnnotation        *ev_annotation_attachment_new            (EvPage            
 EvAttachment        *ev_annotation_attachment_get_attachment (EvAnnotationAttachment *annot);
 gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttachment *annot,
                                                               EvAttachment           *attachment);
+
+/* EvAnnotationTextMarkup */
+GType                ev_annotation_text_markup_get_type     (void) G_GNUC_CONST;
 
 G_END_DECLS
 

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -112,7 +112,8 @@ typedef enum {
 
 typedef enum {
         EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
-        EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT
+        EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT,
+        EV_ANNOTATION_TEXT_MARKUP_UNDERLINE
 } EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
@@ -181,9 +182,10 @@ gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttach
 
 /* EvAnnotationTextMarkup */
 GType                      ev_annotation_text_markup_get_type        (void) G_GNUC_CONST;
-EvAnnotation              *ev_annotation_text_markup_highlight_new   (EvPage *page);
-EvAnnotation              *ev_annotation_text_markup_strike_out_new  (EvPage *page);
-EvAnnotationTextMarkupType ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot);
+EvAnnotation              *ev_annotation_text_markup_highlight_new   (EvPage                    *page);
+EvAnnotation              *ev_annotation_text_markup_strike_out_new  (EvPage                    *page);
+EvAnnotation              *ev_annotation_text_markup_underline_new   (EvPage                    *page);
+EvAnnotationTextMarkupType ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup    *annot);
 
 G_END_DECLS
 

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -113,7 +113,8 @@ typedef enum {
 typedef enum {
         EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
         EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT,
-        EV_ANNOTATION_TEXT_MARKUP_UNDERLINE
+        EV_ANNOTATION_TEXT_MARKUP_UNDERLINE,
+        EV_ANNOTATION_TEXT_MARKUP_SQUIGGLY
 } EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
@@ -188,6 +189,7 @@ GType                      ev_annotation_text_markup_get_type        (void) G_GN
 EvAnnotation              *ev_annotation_text_markup_highlight_new   (EvPage                    *page);
 EvAnnotation              *ev_annotation_text_markup_strike_out_new  (EvPage                    *page);
 EvAnnotation              *ev_annotation_text_markup_underline_new   (EvPage                    *page);
+EvAnnotation              *ev_annotation_text_markup_squiggly_new    (EvPage                    *page);
 EvAnnotationTextMarkupType ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup    *annot);
 gboolean                   ev_annotation_text_markup_set_markup_type (EvAnnotationTextMarkup    *annot,
                                                                       EvAnnotationTextMarkupType markup_type);

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -94,7 +94,7 @@ typedef enum {
     EV_ANNOTATION_TYPE_UNKNOWN,
     EV_ANNOTATION_TYPE_TEXT,
 	EV_ANNOTATION_TYPE_ATTACHMENT,
-	EV_ANNOTATION_TYPE_HIGHLIGHT
+	EV_ANNOTATION_TYPE_TEXT_MARKUP
 } EvAnnotationType;
 
 typedef enum {
@@ -109,6 +109,10 @@ typedef enum {
     EV_ANNOTATION_TEXT_ICON_CIRCLE,
     EV_ANNOTATION_TEXT_ICON_UNKNOWN
 } EvAnnotationTextIcon;
+
+typedef enum {
+        EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT
+} EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
 GType                ev_annotation_get_type                  (void) G_GNUC_CONST;

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -145,6 +145,10 @@ void                 ev_annotation_get_rgba                  (EvAnnotation      
                                                               GdkRGBA                *rgba);
 gboolean             ev_annotation_set_rgba                  (EvAnnotation           *annot,
                                                               const GdkRGBA          *rgba);
+void                 ev_annotation_get_area                  (EvAnnotation           *annot,
+                                                              EvRectangle            *area);
+gboolean             ev_annotation_set_area                  (EvAnnotation           *annot,
+                                                              const EvRectangle      *area);
 
 /* EvAnnotationMarkup */
 GType                ev_annotation_markup_get_type           (void) G_GNUC_CONST;

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -186,6 +186,8 @@ EvAnnotation              *ev_annotation_text_markup_highlight_new   (EvPage    
 EvAnnotation              *ev_annotation_text_markup_strike_out_new  (EvPage                    *page);
 EvAnnotation              *ev_annotation_text_markup_underline_new   (EvPage                    *page);
 EvAnnotationTextMarkupType ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup    *annot);
+gboolean                   ev_annotation_text_markup_set_markup_type (EvAnnotationTextMarkup    *annot,
+                                                                      EvAnnotationTextMarkupType markup_type);
 
 G_END_DECLS
 

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -93,7 +93,8 @@ typedef struct _EvAnnotationTextMarkupClass EvAnnotationTextMarkupClass;
 typedef enum {
     EV_ANNOTATION_TYPE_UNKNOWN,
     EV_ANNOTATION_TYPE_TEXT,
-    EV_ANNOTATION_TYPE_ATTACHMENT
+	EV_ANNOTATION_TYPE_ATTACHMENT,
+	EV_ANNOTATION_TYPE_HIGHLIGHT
 } EvAnnotationType;
 
 typedef enum {
@@ -174,7 +175,8 @@ gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttach
                                                               EvAttachment           *attachment);
 
 /* EvAnnotationTextMarkup */
-GType                ev_annotation_text_markup_get_type     (void) G_GNUC_CONST;
+GType                ev_annotation_text_markup_get_type      (void) G_GNUC_CONST;
+EvAnnotation        *ev_annotation_text_markup_highlight_new (EvPage *page);
 
 G_END_DECLS
 

--- a/libdocument/ev-document-annotations.h
+++ b/libdocument/ev-document-annotations.h
@@ -44,25 +44,26 @@ typedef enum {
 	EV_ANNOTATIONS_SAVE_NONE             = 0,
 	EV_ANNOTATIONS_SAVE_CONTENTS         = 1 << 0,
 	EV_ANNOTATIONS_SAVE_COLOR            = 1 << 1,
+        EV_ANNOTATIONS_SAVE_AREA             = 1 << 2,
 
 	/* Markup Annotations */
-	EV_ANNOTATIONS_SAVE_LABEL            = 1 << 2,
-	EV_ANNOTATIONS_SAVE_OPACITY          = 1 << 3,
-	EV_ANNOTATIONS_SAVE_POPUP_RECT       = 1 << 4,
-	EV_ANNOTATIONS_SAVE_POPUP_IS_OPEN    = 1 << 5,
+	EV_ANNOTATIONS_SAVE_LABEL            = 1 << 3,
+	EV_ANNOTATIONS_SAVE_OPACITY          = 1 << 4,
+	EV_ANNOTATIONS_SAVE_POPUP_RECT       = 1 << 5,
+	EV_ANNOTATIONS_SAVE_POPUP_IS_OPEN    = 1 << 6,
 
 	/* Text Annotations */
-	EV_ANNOTATIONS_SAVE_TEXT_IS_OPEN     = 1 << 6,
-	EV_ANNOTATIONS_SAVE_TEXT_ICON        = 1 << 7,
+	EV_ANNOTATIONS_SAVE_TEXT_IS_OPEN     = 1 << 7,
+	EV_ANNOTATIONS_SAVE_TEXT_ICON        = 1 << 8,
 
 	/* Attachment Annotations */
-	EV_ANNOTATIONS_SAVE_ATTACHMENT       = 1 << 8,
+	EV_ANNOTATIONS_SAVE_ATTACHMENT       = 1 << 9,
 
         /* Text Markup Annotations */
-        EV_ANNOTATIONS_SAVE_TEXT_MARKUP_TYPE = 1 << 9,
+        EV_ANNOTATIONS_SAVE_TEXT_MARKUP_TYPE = 1 << 10,
 
 	/* Save all */
-	EV_ANNOTATIONS_SAVE_ALL              = (1 << 10) - 1
+	EV_ANNOTATIONS_SAVE_ALL              = (1 << 11) - 1
 } EvAnnotationsSaveMask;
 
 typedef struct _EvDocumentAnnotations          EvDocumentAnnotations;

--- a/libdocument/ev-document-annotations.h
+++ b/libdocument/ev-document-annotations.h
@@ -41,25 +41,28 @@ G_BEGIN_DECLS
 #define EV_DOCUMENT_ANNOTATIONS_GET_IFACE(inst) (G_TYPE_INSTANCE_GET_INTERFACE ((inst), EV_TYPE_DOCUMENT_ANNOTATIONS, EvDocumentAnnotationsInterface))
 
 typedef enum {
-	EV_ANNOTATIONS_SAVE_NONE          = 0,
-	EV_ANNOTATIONS_SAVE_CONTENTS      = 1 << 0,
-	EV_ANNOTATIONS_SAVE_COLOR         = 1 << 1,
+	EV_ANNOTATIONS_SAVE_NONE             = 0,
+	EV_ANNOTATIONS_SAVE_CONTENTS         = 1 << 0,
+	EV_ANNOTATIONS_SAVE_COLOR            = 1 << 1,
 
 	/* Markup Annotations */
-	EV_ANNOTATIONS_SAVE_LABEL         = 1 << 2,
-	EV_ANNOTATIONS_SAVE_OPACITY       = 1 << 3,
-	EV_ANNOTATIONS_SAVE_POPUP_RECT    = 1 << 4,
-	EV_ANNOTATIONS_SAVE_POPUP_IS_OPEN = 1 << 5,
+	EV_ANNOTATIONS_SAVE_LABEL            = 1 << 2,
+	EV_ANNOTATIONS_SAVE_OPACITY          = 1 << 3,
+	EV_ANNOTATIONS_SAVE_POPUP_RECT       = 1 << 4,
+	EV_ANNOTATIONS_SAVE_POPUP_IS_OPEN    = 1 << 5,
 
 	/* Text Annotations */
-	EV_ANNOTATIONS_SAVE_TEXT_IS_OPEN  = 1 << 6,
-	EV_ANNOTATIONS_SAVE_TEXT_ICON     = 1 << 7,
+	EV_ANNOTATIONS_SAVE_TEXT_IS_OPEN     = 1 << 6,
+	EV_ANNOTATIONS_SAVE_TEXT_ICON        = 1 << 7,
 
 	/* Attachment Annotations */
-	EV_ANNOTATIONS_SAVE_ATTACHMENT    = 1 << 8,
+	EV_ANNOTATIONS_SAVE_ATTACHMENT       = 1 << 8,
+
+        /* Text Markup Annotations */
+        EV_ANNOTATIONS_SAVE_TEXT_MARKUP_TYPE = 1 << 9,
 
 	/* Save all */
-	EV_ANNOTATIONS_SAVE_ALL           = (1 << 9) - 1
+	EV_ANNOTATIONS_SAVE_ALL              = (1 << 10) - 1
 } EvAnnotationsSaveMask;
 
 typedef struct _EvDocumentAnnotations          EvDocumentAnnotations;

--- a/libview/ev-annotation-window.c
+++ b/libview/ev-annotation-window.c
@@ -427,6 +427,23 @@ ev_annotation_window_constructor (GType                  type,
 }
 
 static gboolean
+ev_annotation_window_key_press_event (GtkWidget   *widget,
+                                      GdkEventKey *event)
+{
+	EvAnnotationWindow *window = EV_ANNOTATION_WINDOW (widget);
+
+	switch (event->keyval) {
+		case GDK_KEY_Escape:
+			ev_annotation_window_close(window);
+			return TRUE;
+	}
+
+	/* handle other key events of the focused widget */
+	return gtk_window_propagate_key_event (GTK_WINDOW (window), event);
+}
+
+
+static gboolean
 ev_annotation_window_button_press_event (GtkWidget      *widget,
 					 GdkEventButton *event)
 {
@@ -460,6 +477,14 @@ ev_annotation_window_configure_event (GtkWidget         *widget,
 	}
 
 	return GTK_WIDGET_CLASS (ev_annotation_window_parent_class)->configure_event (widget, event);
+}
+
+static gboolean
+ev_annotation_window_hide_on_delete (GtkWidget *widget, GdkEventAny *event) {
+
+	EvAnnotationWindow *window = EV_ANNOTATION_WINDOW (widget);
+	ev_annotation_window_close(window);
+	return TRUE;
 }
 
 static gboolean
@@ -506,9 +531,11 @@ ev_annotation_window_class_init (EvAnnotationWindowClass *klass)
 	g_object_class->dispose = ev_annotation_window_dispose;
 
 	gtk_widget_class->button_press_event = ev_annotation_window_button_press_event;
+	gtk_widget_class->key_press_event = ev_annotation_window_key_press_event;
 	gtk_widget_class->configure_event = ev_annotation_window_configure_event;
 	gtk_widget_class->focus_in_event = ev_annotation_window_focus_in_event;
 	gtk_widget_class->focus_out_event = ev_annotation_window_focus_out_event;
+	gtk_widget_class->delete_event = ev_annotation_window_hide_on_delete;
 
 	g_object_class_install_property (g_object_class,
 					 PROP_ANNOTATION,

--- a/libview/ev-page-cache.c
+++ b/libview/ev-page-cache.c
@@ -342,8 +342,9 @@ ev_page_cache_set_flags (EvPageCache       *cache,
 }
 
 void
-ev_page_cache_mark_dirty (EvPageCache *cache,
-			  gint         page)
+ev_page_cache_mark_dirty (EvPageCache       *cache,
+                          gint               page,
+                          EvJobPageDataFlags flags)
 {
 	EvPageCacheData *data;
 
@@ -351,6 +352,29 @@ ev_page_cache_mark_dirty (EvPageCache *cache,
 
 	data = &cache->page_list[page];
 	data->dirty = TRUE;
+
+	if (flags & EV_PAGE_DATA_INCLUDE_LINKS)
+		g_clear_pointer (&data->link_mapping, ev_mapping_list_unref);
+
+	if (flags & EV_PAGE_DATA_INCLUDE_IMAGES)
+		g_clear_pointer (&data->image_mapping, ev_mapping_list_unref);
+
+	if (flags & EV_PAGE_DATA_INCLUDE_FORMS)
+		g_clear_pointer (&data->form_field_mapping, ev_mapping_list_unref);
+
+	if (flags & EV_PAGE_DATA_INCLUDE_ANNOTS)
+		g_clear_pointer (&data->annot_mapping, ev_mapping_list_unref);
+
+	if (flags & EV_PAGE_DATA_INCLUDE_TEXT_MAPPING)
+		g_clear_pointer (&data->text_mapping, cairo_region_destroy);
+
+	if (flags & EV_PAGE_DATA_INCLUDE_TEXT)
+		g_clear_pointer (&data->text, g_free);
+
+	if (flags & EV_PAGE_DATA_INCLUDE_TEXT_LAYOUT) {
+		g_clear_pointer (&data->text_layout, g_free);
+		data->text_layout_length = 0;
+	}
 
 	/* Update the current range */
 	ev_page_cache_set_page_range (cache, cache->start_page, cache->end_page);

--- a/libview/ev-page-cache.h
+++ b/libview/ev-page-cache.h
@@ -48,7 +48,8 @@ EvJobPageDataFlags ev_page_cache_get_flags              (EvPageCache       *cach
 void               ev_page_cache_set_flags              (EvPageCache       *cache,
 							 EvJobPageDataFlags flags);
 void               ev_page_cache_mark_dirty             (EvPageCache       *cache,
-							 gint               page);
+							 gint               page,
+                                                         EvJobPageDataFlags flags);
 EvMappingList     *ev_page_cache_get_link_mapping       (EvPageCache       *cache,
 							 gint               page);
 EvMappingList     *ev_page_cache_get_image_mapping      (EvPageCache       *cache,

--- a/libview/ev-view-accessible.c
+++ b/libview/ev-view-accessible.c
@@ -1,5 +1,5 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8; c-indent-level: 8 -*- */
-/* this file is part of xreader, a mate document viewer
+/* this file is part of xreader, a generic document viewer
  *
  *  Copyright (C) 2004 Red Hat, Inc
  *
@@ -488,7 +488,7 @@ ev_view_accessible_get_offset_at_point (AtkText      *text,
 	}
 
 	ev_view_get_page_extents (view, view->current_page, &page_area, &border);
-	_ev_view_transform_view_point_to_doc_point (view, &view_point, &page_area, &doc_x, &doc_y);
+	_ev_view_transform_view_point_to_doc_point (view, &view_point, &page_area, &border, &doc_x, &doc_y);
 
 	for (i = 0; i < n_areas; i++) {
 		rect = areas + i;

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -254,11 +254,13 @@ void _get_page_size_for_scale_and_rotation (EvDocument *document,
 void _ev_view_transform_view_point_to_doc_point (EvView       *view,
 						 GdkPoint     *view_point,
 						 GdkRectangle *page_area,
+						 GtkBorder    *border,
 						 double       *doc_point_x,
 						 double       *doc_point_y);
 void _ev_view_transform_view_rect_to_doc_rect (EvView       *view,
 					       GdkRectangle *view_rect,
 					       GdkRectangle *page_area,
+					       GtkBorder    *border,
 					       EvRectangle  *doc_rect);
 void _ev_view_transform_doc_point_to_view_point (EvView   *view,
 						 int       page,

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -211,7 +211,8 @@ struct _EvView {
 	EvViewWindowChild *window_child_focus;
 	EvMapping         *focus_annotation;
 	AddingAnnotInfo    adding_annot_info;
-	
+	GHashTable        *annot_window_map;
+
 	/* Focus */
 	EvMapping *focused_element;
 	guint focused_element_page;

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -1,5 +1,5 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8; c-indent-level: 8 -*- */
-/* this file is part of xreader, a mate document viewer
+/* this file is part of xreader, a generic document viewer
  *
  *  Copyright (C) 2004 Red Hat, Inc
  *
@@ -114,11 +114,21 @@ typedef struct _EvHeightToPageCache {
 	gdouble *dual_height_to_page;
 } EvHeightToPageCache;
 
+/* Information for handling annotations */
+typedef struct {
+	GdkPoint         start;
+	GdkPoint         stop;
+	gboolean         adding_annot;
+	EvAnnotationType type;
+	EvAnnotation    *annot;
+} AddingAnnotInfo;
+
 struct _EvView {
 	GtkLayout layout;
 
 	/* Container */
 	GList *children;
+
 	EvDocument *document;
 
 	/* Find */
@@ -200,8 +210,7 @@ struct _EvView {
 	GList             *window_children;
 	EvViewWindowChild *window_child_focus;
 	EvMapping         *focus_annotation;
-	gboolean           adding_annot;
-	EvAnnotationType   adding_annot_type;
+	AddingAnnotInfo    adding_annot_info;
 	
 	/* Focus */
 	EvMapping *focused_element;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4346,7 +4346,9 @@ ev_view_button_release_event (GtkWidget      *widget,
 	if (view->adding_annot_info.adding_annot) {
 		gboolean annot_added = TRUE;
 
-		g_assert (view->pressed_button == 1);
+		/* We ignore right-click buttons while in annotation add mode */
+		if (view->pressed_button != 1)
+			return FALSE;
 		g_assert (view->adding_annot_info.annot);
 
 		if (EV_IS_ANNOTATION_MARKUP (view->adding_annot_info.annot)) {

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3064,7 +3064,7 @@ ev_view_create_annotation (EvView *view)
 
 	/* If the page didn't have annots, mark the cache as dirty */
 	if (!ev_page_cache_get_annot_mapping (view->page_cache, view->current_page))
-		ev_page_cache_mark_dirty (view->page_cache, view->current_page);
+		ev_page_cache_mark_dirty (view->page_cache, view->current_page, EV_PAGE_DATA_INCLUDE_ANNOTS);
 
 	_ev_view_transform_doc_rect_to_view_rect (view, view->current_page, &doc_rect, &view_rect);
 	view_rect.x -= view->scroll_x;
@@ -3154,7 +3154,7 @@ ev_view_remove_annotation (EvView       *view,
 							annot);
 	ev_document_doc_mutex_unlock ();
 
-	ev_page_cache_mark_dirty (view->page_cache, page);
+    ev_page_cache_mark_dirty (view->page_cache, page, EV_PAGE_DATA_INCLUDE_ANNOTS);
 
 	/* FIXME: only redraw the annot area */
 	ev_view_reload_page (view, page, NULL);
@@ -4365,7 +4365,7 @@ ev_view_button_release_event (GtkWidget      *widget,
 				ev_document_annotations_remove_annotation (EV_DOCUMENT_ANNOTATIONS (view->document),
 									   view->adding_annot_info.annot);
 				ev_document_doc_mutex_unlock ();
-				ev_page_cache_mark_dirty (view->page_cache, view->current_page);
+				ev_page_cache_mark_dirty (view->page_cache, view->current_page, EV_PAGE_DATA_INCLUDE_ANNOTS);
 			} else {
 				popup_rect.x1 = area.x2;
 				popup_rect.x2 = popup_rect.x1 + ANNOT_POPUP_WINDOW_DEFAULT_WIDTH;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4344,6 +4344,8 @@ ev_view_button_release_event (GtkWidget      *widget,
 	view->drag_info.in_drag = FALSE;
 
 	if (view->adding_annot_info.adding_annot) {
+		gboolean annot_added = TRUE;
+
 		g_assert (view->pressed_button == 1);
 		g_assert (view->adding_annot_info.annot);
 
@@ -4354,30 +4356,43 @@ ev_view_button_release_event (GtkWidget      *widget,
 			EvRectangle popup_rect;
 
 			ev_annotation_get_area (view->adding_annot_info.annot, &area);
-			popup_rect.x1 = area.x2;
-			popup_rect.x2 = popup_rect.x1 + ANNOT_POPUP_WINDOW_DEFAULT_WIDTH;
-			popup_rect.y1 = area.y2;
-			popup_rect.y2 = popup_rect.y1 + ANNOT_POPUP_WINDOW_DEFAULT_HEIGHT;
 
-			if (ev_annotation_markup_set_rectangle (EV_ANNOTATION_MARKUP (view->adding_annot_info.annot),
-								&popup_rect)) {
+			if (area.x1 == 0 && area.y1 == 0 && area.x2 == 0 && area.y2 == 0) {
+				/* Do not create empty annots */
+				annot_added = FALSE;
+
 				ev_document_doc_mutex_lock ();
-				ev_document_annotations_save_annotation (EV_DOCUMENT_ANNOTATIONS (view->document),
-									 view->adding_annot_info.annot,
-									 EV_ANNOTATIONS_SAVE_POPUP_RECT);
+				ev_document_annotations_remove_annotation (EV_DOCUMENT_ANNOTATIONS (view->document),
+									   view->adding_annot_info.annot);
 				ev_document_doc_mutex_unlock ();
-			}
+				ev_page_cache_mark_dirty (view->page_cache, view->current_page);
+			} else {
+				popup_rect.x1 = area.x2;
+				popup_rect.x2 = popup_rect.x1 + ANNOT_POPUP_WINDOW_DEFAULT_WIDTH;
+				popup_rect.y1 = area.y2;
+				popup_rect.y2 = popup_rect.y1 + ANNOT_POPUP_WINDOW_DEFAULT_HEIGHT;
 
-			parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
-			window = ev_view_create_annotation_window (view, view->adding_annot_info.annot, parent);
-			/* Show the annot window the first time for text annotations */
-			if (view->adding_annot_info.type == EV_ANNOTATION_TYPE_TEXT)
-				ev_view_annotation_show_popup_window (view, window);
+				if (ev_annotation_markup_set_rectangle (EV_ANNOTATION_MARKUP (view->adding_annot_info.annot),
+									&popup_rect)) {
+					ev_document_doc_mutex_lock ();
+					ev_document_annotations_save_annotation (EV_DOCUMENT_ANNOTATIONS (view->document),
+										 view->adding_annot_info.annot,
+										 EV_ANNOTATIONS_SAVE_POPUP_RECT);
+					ev_document_doc_mutex_unlock ();
+				}
+
+				parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
+				window = ev_view_create_annotation_window (view, view->adding_annot_info.annot, parent);
+				/* Show the annot window the first time for text annotations */
+				if (view->adding_annot_info.type == EV_ANNOTATION_TYPE_TEXT)
+					ev_view_annotation_show_popup_window (view, window);
+			}
 		}
 
 		view->adding_annot_info.stop.x = event->x + view->scroll_x;
 		view->adding_annot_info.stop.y = event->y + view->scroll_y;
-		g_signal_emit (view, signals[SIGNAL_ANNOT_ADDED], 0, view->adding_annot_info.annot);
+		if (annot_added)
+			g_signal_emit (view, signals[SIGNAL_ANNOT_ADDED], 0, view->adding_annot_info.annot);
 
 		view->adding_annot_info.adding_annot = FALSE;
 		view->adding_annot_info.annot = NULL;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3086,6 +3086,8 @@ ev_view_create_annotation (EvView *view)
 	}
 	ev_document_annotations_add_annotation (EV_DOCUMENT_ANNOTATIONS (view->document),
 						annot, &doc_rect);
+	/* Re-fetch area as eg. adding Text Markup annots updates area for its bounding box */
+	ev_annotation_get_area (annot, &doc_rect);
 	ev_document_doc_mutex_unlock ();
 
 	/* If the page didn't have annots, mark the cache as dirty */

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4380,9 +4380,13 @@ ev_view_button_release_event (GtkWidget      *widget,
 										 EV_ANNOTATIONS_SAVE_POPUP_RECT);
 					ev_document_doc_mutex_unlock ();
 				}
+				/* the annotation window might already exist */
+				window = get_window_for_annot (view, view->adding_annot_info.annot);
 
-				parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
-				window = ev_view_create_annotation_window (view, view->adding_annot_info.annot, parent);
+				if (window == NULL) {
+					parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
+					window = ev_view_create_annotation_window (view, view->adding_annot_info.annot, parent);
+				}
 				/* Show the annot window the first time for text annotations */
 				if (view->adding_annot_info.type == EV_ANNOTATION_TYPE_TEXT)
 					ev_view_annotation_show_popup_window (view, window);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -2677,31 +2677,6 @@ ev_view_window_child_put (EvView    *view,
 	view->window_children = g_list_append (view->window_children, child);
 }
 
-static EvViewWindowChild *
-ev_view_find_window_child_for_annot (EvView       *view,
-				     guint         page,
-				     EvAnnotation *annot)
-{
-	GList *children = view->window_children;
-
-	while (children) {
-		EvViewWindowChild *child;
-		EvAnnotation      *wannot;
-
-		child = (EvViewWindowChild *)children->data;
-		children = children->next;
-
-		if (child->page != page)
-			continue;
-
-		wannot = ev_annotation_window_get_annotation (EV_ANNOTATION_WINDOW (child->window));
-		if (ev_annotation_equal (wannot, annot))
-			return child;
-	}
-
-	return NULL;
-}
-
 static void
 ev_view_remove_window_child_for_annot (EvView       *view,
 				     guint         page,
@@ -2719,7 +2694,6 @@ ev_view_remove_window_child_for_annot (EvView       *view,
 			children = children->next;
 			continue;
 		}
-
 		wannot = ev_annotation_window_get_annotation (EV_ANNOTATION_WINDOW (child->window));
 		if (ev_annotation_equal (wannot, annot)) {
 			gtk_widget_destroy (child->window);
@@ -2729,6 +2703,7 @@ ev_view_remove_window_child_for_annot (EvView       *view,
 		children = children->next;
 	}
 }
+
 static void
 ev_view_window_children_free (EvView *view)
 {
@@ -2870,7 +2845,6 @@ show_annotation_windows (EvView *view,
 
 	for (l = ev_mapping_list_get_list (annots); l && l->data; l = g_list_next (l)) {
 		EvAnnotation      *annot;
-		EvViewWindowChild *child;
 		GtkWidget         *window;
 
 		annot = ((EvMapping *)(l->data))->data;
@@ -2883,16 +2857,6 @@ show_annotation_windows (EvView *view,
 
 		window = get_window_for_annot (view, annot);
 		if (window) {
-			ev_view_window_child_move_with_parent (view, window);
-			continue;
-		}
-
-		/* Look if we already have a popup for this annot */
-		child = ev_view_find_window_child_for_annot (view, page, annot);
-		window = child ? child->window : NULL;
-		if (window) {
-			ev_annotation_window_set_annotation (EV_ANNOTATION_WINDOW (window), annot);
-			map_annot_to_window (view, annot, window);
 			ev_view_window_child_move_with_parent (view, window);
 		} else {
 			ev_view_create_annotation_window (view, annot, parent);
@@ -3174,16 +3138,8 @@ ev_view_remove_annotation (EvView       *view,
 
 	page = ev_annotation_get_page_index (annot);
 
-    if (EV_IS_ANNOTATION_MARKUP (annot)) {
-		EvViewWindowChild *child;
-
-		child = ev_view_find_window_child_for_annot (view, page, annot);
-		if (child) {
-			view->window_children = g_list_remove (view->window_children, child);
-			gtk_widget_destroy (child->window);
-			g_free (child);
-		}
-    }
+    if (EV_IS_ANNOTATION_MARKUP (annot))
+		ev_view_remove_window_child_for_annot (view, page, annot);
 	if (view->annot_window_map != NULL)
 		g_hash_table_remove (view->annot_window_map, annot);
 
@@ -4525,10 +4481,10 @@ ev_view_key_press_event (GtkWidget   *widget,
 			g_object_ref (new_event->window);
 		gtk_widget_realize (child_widget);
 		handled = gtk_widget_event (child_widget, (GdkEvent *)new_event);
-			gdk_event_free ((GdkEvent *)new_event);
+		gdk_event_free ((GdkEvent *)new_event);
 
-			return handled;
-		}
+		return handled;
+	}
 
 
 	return gtk_bindings_activate_event (G_OBJECT (widget), event);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3035,6 +3035,7 @@ ev_view_create_annotation (EvView *view)
 	}
 	g_object_unref (page);
 
+	ev_annotation_set_area (annot, &doc_rect);
 	ev_annotation_set_color (annot, &color);
 
 	if (EV_IS_ANNOTATION_MARKUP (annot)) {

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3025,6 +3025,13 @@ ev_view_create_annotation (EvView *view)
         doc_rect.y2 = doc_rect.y1 + ANNOTATION_ICON_SIZE;
 		annot = ev_annotation_text_new (page);
 		break;
+	case EV_ANNOTATION_TYPE_TEXT_MARKUP:
+		doc_rect.x1 = start.x;
+		doc_rect.y1 = start.y;
+		doc_rect.x2 = end.x;
+		doc_rect.y2 = end.y;
+		annot = ev_annotation_text_markup_highlight_new (page);
+		break;
 	case EV_ANNOTATION_TYPE_ATTACHMENT:
 		/* TODO */
 		g_object_unref (page);
@@ -4190,6 +4197,12 @@ ev_view_motion_notify_event (GtkWidget      *widget,
 				rect.y1 = end.y;
 				rect.x2 = rect.x1 + current_area.x2 - current_area.x1;
 				rect.y2 = rect.y1 + current_area.y2 - current_area.y1;
+				break;
+			case EV_ANNOTATION_TYPE_TEXT_MARKUP:
+				rect.x1 = start.x;
+				rect.y1 = start.y;
+				rect.x2 = end.x;
+				rect.y2 = end.y;
 				break;
 			default:
 				g_assert_not_reached ();

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3040,9 +3040,9 @@ ev_view_create_annotation (EvView *view)
 
 	if (EV_IS_ANNOTATION_MARKUP (annot)) {
 		popup_rect.x1 = doc_rect.x2;
-		popup_rect.x2 = popup_rect.x1 + 200;
+		popup_rect.x2 = popup_rect.x1 + ANNOT_POPUP_WINDOW_DEFAULT_WIDTH;
 		popup_rect.y1 = doc_rect.y2;
-		popup_rect.y2 = popup_rect.y1 + 150;
+		popup_rect.y2 = popup_rect.y1 + ANNOT_POPUP_WINDOW_DEFAULT_HEIGHT;
 		g_object_set (annot,
 			      "rectangle", &popup_rect,
 			      "has_popup", TRUE,
@@ -3058,17 +3058,6 @@ ev_view_create_annotation (EvView *view)
 	/* If the page didn't have annots, mark the cache as dirty */
 	if (!ev_page_cache_get_annot_mapping (view->page_cache, view->current_page))
 		ev_page_cache_mark_dirty (view->page_cache, view->current_page);
-
-	if (EV_IS_ANNOTATION_MARKUP (annot)) {
-		GtkWindow *parent;
-		GtkWidget *window;
-
-		parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
-		window = ev_view_create_annotation_window (view, annot, parent);
-
-		/* Show the annot window the first time */
-		ev_view_annotation_show_popup_window (view, window);
-	}
 
 	_ev_view_transform_doc_rect_to_view_rect (view, view->current_page, &doc_rect, &view_rect);
 	view_rect.x -= view->scroll_x;
@@ -4174,7 +4163,52 @@ ev_view_motion_notify_event (GtkWidget      *widget,
 		if (view->rotation != 0)
 			return FALSE;
 
-		if (!view->adding_annot_info.adding_annot) {
+		if (view->adding_annot_info.adding_annot) {
+			EvRectangle  rect;
+			EvRectangle  current_area;
+			EvPoint      start;
+			EvPoint      end;
+			GdkRectangle page_area;
+			GtkBorder    border;
+
+			if (!view->adding_annot_info.annot)
+				return TRUE;
+
+			ev_annotation_get_area (view->adding_annot_info.annot, &current_area);
+
+			view->adding_annot_info.stop.x = event->x + view->scroll_x;
+			view->adding_annot_info.stop.y = event->y + view->scroll_y;
+			ev_view_get_page_extents (view, view->current_page, &page_area, &border);
+			_ev_view_transform_view_point_to_doc_point (view, &view->adding_annot_info.start, &page_area, &border,
+								    &start.x, &start.y);
+			_ev_view_transform_view_point_to_doc_point (view, &view->adding_annot_info.stop, &page_area, &border,
+								    &end.x, &end.y);
+
+			switch (view->adding_annot_info.type) {
+			case EV_ANNOTATION_TYPE_TEXT:
+				rect.x1 = end.x;
+				rect.y1 = end.y;
+				rect.x2 = rect.x1 + current_area.x2 - current_area.x1;
+				rect.y2 = rect.y1 + current_area.y2 - current_area.y1;
+				break;
+			default:
+				g_assert_not_reached ();
+			}
+
+			/* Take the mutex before set_area, because the notify signal
+			 * updates the mappings in the backend */
+			ev_document_doc_mutex_lock ();
+			if (ev_annotation_set_area (view->adding_annot_info.annot, &rect)) {
+				ev_document_annotations_save_annotation (EV_DOCUMENT_ANNOTATIONS (view->document),
+									 view->adding_annot_info.annot,
+									 EV_ANNOTATIONS_SAVE_AREA);
+			}
+			ev_document_doc_mutex_unlock ();
+
+
+			/* FIXME: reload only annotation area */
+			ev_view_reload_page (view, view->current_page, NULL);
+		} else {
 			/* Schedule timeout to scroll during selection and additionally
 			 * scroll once to allow arbitrary speed. */
 			if (!view->selection_scroll_id)
@@ -4299,6 +4333,34 @@ ev_view_button_release_event (GtkWidget      *widget,
 	if (view->adding_annot_info.adding_annot) {
 		g_assert (view->pressed_button == 1);
 		g_assert (view->adding_annot_info.annot);
+
+		if (EV_IS_ANNOTATION_MARKUP (view->adding_annot_info.annot)) {
+			GtkWindow  *parent;
+			GtkWidget  *window;
+			EvRectangle area;
+			EvRectangle popup_rect;
+
+			ev_annotation_get_area (view->adding_annot_info.annot, &area);
+			popup_rect.x1 = area.x2;
+			popup_rect.x2 = popup_rect.x1 + ANNOT_POPUP_WINDOW_DEFAULT_WIDTH;
+			popup_rect.y1 = area.y2;
+			popup_rect.y2 = popup_rect.y1 + ANNOT_POPUP_WINDOW_DEFAULT_HEIGHT;
+
+			if (ev_annotation_markup_set_rectangle (EV_ANNOTATION_MARKUP (view->adding_annot_info.annot),
+								&popup_rect)) {
+				ev_document_doc_mutex_lock ();
+				ev_document_annotations_save_annotation (EV_DOCUMENT_ANNOTATIONS (view->document),
+									 view->adding_annot_info.annot,
+									 EV_ANNOTATIONS_SAVE_POPUP_RECT);
+				ev_document_doc_mutex_unlock ();
+			}
+
+			parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
+			window = ev_view_create_annotation_window (view, view->adding_annot_info.annot, parent);
+			/* Show the annot window the first time for text annotations */
+			if (view->adding_annot_info.type == EV_ANNOTATION_TYPE_TEXT)
+				ev_view_annotation_show_popup_window (view, window);
+		}
 
 		view->adding_annot_info.stop.x = event->x + view->scroll_x;
 		view->adding_annot_info.stop.y = event->y + view->scroll_y;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3749,7 +3749,8 @@ ev_view_query_tooltip (GtkWidget  *widget,
 	if (annot) {
 		const gchar *contents;
 
-		if ((contents = ev_annotation_get_contents (annot))) {
+		contents = ev_annotation_get_contents (annot);
+		if (contents && *contents != '\0') {
 			GdkRectangle annot_area;
 
 			get_annot_area (view, x, y, annot, &annot_area);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -104,6 +104,9 @@ typedef struct {
 #define EV_STYLE_CLASS_DOCUMENT_PAGE "document-page"
 #define EV_STYLE_CLASS_INVERTED      "inverted"
 
+#define ANNOT_POPUP_WINDOW_DEFAULT_WIDTH  200
+#define ANNOT_POPUP_WINDOW_DEFAULT_HEIGHT 150
+
 /*** Scrolling ***/
 static void       view_update_range_and_current_page         (EvView             *view);
 static void       add_scroll_binding_keypad                  (GtkBindingSet      *binding_set,
@@ -2943,6 +2946,29 @@ ev_view_handle_annotation (EvView       *view,
 		GtkWidget *window;
 
 		window = g_object_get_data (G_OBJECT (annot), "popup");
+		if (!window && ev_annotation_markup_can_have_popup (EV_ANNOTATION_MARKUP (annot))) {
+			EvRectangle    popup_rect;
+			GtkWindow     *parent;
+			EvMappingList *annots;
+			EvMapping     *mapping;
+
+			annots = ev_page_cache_get_annot_mapping (view->page_cache,
+								  ev_annotation_get_page_index (annot));
+			mapping = ev_mapping_list_find (annots, annot);
+
+			popup_rect.x1 = mapping->area.x2;
+			popup_rect.y1 = mapping->area.y2;
+			popup_rect.x2 = popup_rect.x1 + ANNOT_POPUP_WINDOW_DEFAULT_WIDTH;
+			popup_rect.y2 = popup_rect.y1 + ANNOT_POPUP_WINDOW_DEFAULT_HEIGHT;
+			g_object_set (annot,
+				      "rectangle", &popup_rect,
+				      "has_popup", TRUE,
+				      "popup_is_open", TRUE,
+				      NULL);
+
+			parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
+			window = ev_view_create_annotation_window (view, annot, parent);
+		}
 		ev_view_annotation_show_popup_window (view, window);
 	}
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -106,6 +106,7 @@ typedef struct {
 
 #define ANNOT_POPUP_WINDOW_DEFAULT_WIDTH  200
 #define ANNOT_POPUP_WINDOW_DEFAULT_HEIGHT 150
+#define ANNOTATION_ICON_SIZE 24
 
 /*** Scrolling ***/
 static void       view_update_range_and_current_page         (EvView             *view);
@@ -1915,7 +1916,7 @@ ev_view_handle_cursor_over_xy (EvView *view, gint x, gint y)
 	if (view->cursor == EV_VIEW_CURSOR_HIDDEN)
 		return;
 
-	if (view->adding_annot) {
+	if (view->adding_annot_info.adding_annot && !view->adding_annot_info.annot) {
 		if (view->cursor != EV_VIEW_CURSOR_ADD)
 			ev_view_set_cursor (view, EV_VIEW_CURSOR_ADD);
 		return;
@@ -2995,13 +2996,11 @@ ev_view_handle_annotation (EvView       *view,
 }
 
 static void
-ev_view_create_annotation (EvView          *view,
-			   EvAnnotationType annot_type,
-			   gint             x,
-			   gint             y)
+ev_view_create_annotation (EvView *view)
 {
 	EvAnnotation   *annot;
-	GdkPoint        point;
+	EvPoint         start;
+	EvPoint         end;
 	GdkRectangle    page_area;
 	GtkBorder       border;
 	EvRectangle     doc_rect, popup_rect;
@@ -3010,18 +3009,20 @@ ev_view_create_annotation (EvView          *view,
 	GdkRectangle    view_rect;
 	cairo_region_t *region;
 
-	point.x = x;
-	point.y = y;
 	ev_view_get_page_extents (view, view->current_page, &page_area, &border);
-	_ev_view_transform_view_point_to_doc_point (view, &point, &page_area, &border,
-						    &doc_rect.x1, &doc_rect.y1);
-	doc_rect.x2 = doc_rect.x1 + 24;
-	doc_rect.y2 = doc_rect.y1 + 24;
+	_ev_view_transform_view_point_to_doc_point (view, &view->adding_annot_info.start, &page_area, &border,
+						    &start.x, &start.y);
+	_ev_view_transform_view_point_to_doc_point (view, &view->adding_annot_info.stop, &page_area, &border,
+						    &end.x, &end.y);
 
 	ev_document_doc_mutex_lock ();
 	page = ev_document_get_page (view->document, view->current_page);
-	switch (annot_type) {
+    switch (view->adding_annot_info.type) {
 	case EV_ANNOTATION_TYPE_TEXT:
+        doc_rect.x1 = end.x;
+        doc_rect.y1 = end.y;
+        doc_rect.x2 = doc_rect.x1 + ANNOTATION_ICON_SIZE;
+        doc_rect.y2 = doc_rect.y1 + ANNOTATION_ICON_SIZE;
 		annot = ev_annotation_text_new (page);
 		break;
 	case EV_ANNOTATION_TYPE_ATTACHMENT:
@@ -3075,7 +3076,8 @@ ev_view_create_annotation (EvView          *view,
 	ev_view_reload_page (view, view->current_page, region);
 	cairo_region_destroy (region);
 
-	g_signal_emit (view, signals[SIGNAL_ANNOT_ADDED], 0, annot);
+	view->adding_annot_info.annot = annot;
+	ev_view_set_cursor (view, EV_VIEW_CURSOR_NORMAL);
 }
 
 void
@@ -3112,11 +3114,11 @@ ev_view_begin_add_annotation (EvView          *view,
 	if (annot_type == EV_ANNOTATION_TYPE_UNKNOWN)
 		return;
 
-	if (view->adding_annot)
+	if (view->adding_annot_info.adding_annot)
 		return;
 
-	view->adding_annot = TRUE;
-	view->adding_annot_type = annot_type;
+	view->adding_annot_info.adding_annot = TRUE;
+	view->adding_annot_info.type = annot_type;
 	ev_view_set_cursor (view, EV_VIEW_CURSOR_ADD);
 }
 
@@ -3125,10 +3127,11 @@ ev_view_cancel_add_annotation (EvView *view)
 {
 	gint x, y;
 
-	if (!view->adding_annot)
+	if (!view->adding_annot_info.adding_annot)
 		return;
 
-	view->adding_annot = FALSE;
+	view->adding_annot_info.adding_annot = FALSE;
+	g_assert(!view->adding_annot_info.annot);
 	ev_document_misc_get_pointer_position (GTK_WIDGET (view), &x, &y);
 	ev_view_handle_cursor_over_xy (view, x, y);
 }
@@ -3799,11 +3802,20 @@ ev_view_button_press_event (GtkWidget      *widget,
 	view->pressed_button = event->button;
 	view->selection_info.in_drag = FALSE;
 
-	if (view->adding_annot)
-		return FALSE;
-
 	if (view->scroll_info.autoscrolling)
 		return TRUE;
+
+	if (view->adding_annot_info.adding_annot && !view->adding_annot_info.annot) {
+		if (event->button != 1)
+			return TRUE;
+
+		view->adding_annot_info.start.x = event->x + view->scroll_x;
+		view->adding_annot_info.start.y = event->y + view->scroll_y;
+		view->adding_annot_info.stop = view->adding_annot_info.start;
+		ev_view_create_annotation (view);
+
+		return TRUE;
+	}
 
 	switch (event->button) {
 	        case 1: {
@@ -4161,26 +4173,28 @@ ev_view_motion_notify_event (GtkWidget      *widget,
 		if (view->rotation != 0)
 			return FALSE;
 
-		/* Schedule timeout to scroll during selection and additionally
-		 * scroll once to allow arbitrary speed. */
-		if (!view->selection_scroll_id)
-		    view->selection_scroll_id = g_timeout_add (SCROLL_TIME,
-							       (GSourceFunc)selection_scroll_timeout_cb,
-							       view);
-		else
-		    selection_scroll_timeout_cb (view);
+		if (!view->adding_annot_info.adding_annot) {
+			/* Schedule timeout to scroll during selection and additionally
+			 * scroll once to allow arbitrary speed. */
+			if (!view->selection_scroll_id)
+				view->selection_scroll_id = g_timeout_add (SCROLL_TIME,
+									   (GSourceFunc)selection_scroll_timeout_cb,
+									   view);
+			else
+				selection_scroll_timeout_cb (view);
 
-		view->selection_info.in_selection = TRUE;
-		view->motion.x = x + view->scroll_x;
-		view->motion.y = y + view->scroll_y;
+			view->selection_info.in_selection = TRUE;
+			view->motion.x = x + view->scroll_x;
+			view->motion.y = y + view->scroll_y;
 
-		/* Queue an idle to handle the motion.  We do this because
-		 * handling any selection events in the motion could be slower
-		 * than new motion events reach us.  We always put it in the
-		 * idle to make sure we catch up and don't visibly lag the
-		 * mouse. */
-		if (!view->selection_update_id)
-			view->selection_update_id = g_idle_add ((GSourceFunc)selection_update_idle_cb, view);
+			/* Queue an idle to handle the motion.  We do this because
+			 * handling any selection events in the motion could be slower
+			 * than new motion events reach us.  We always put it in the
+			 * idle to make sure we catch up and don't visibly lag the
+			 * mouse. */
+			if (!view->selection_update_id)
+				view->selection_update_id = g_idle_add ((GSourceFunc)selection_update_idle_cb, view);
+		}
 
 		return TRUE;
 	case 2:
@@ -4281,15 +4295,18 @@ ev_view_button_release_event (GtkWidget      *widget,
 
 	view->drag_info.in_drag = FALSE;
 
-	if (view->adding_annot && view->pressed_button == 1) {
-		view->adding_annot = FALSE;
+	if (view->adding_annot_info.adding_annot) {
+		g_assert (view->pressed_button == 1);
+		g_assert (view->adding_annot_info.annot);
+
+		view->adding_annot_info.stop.x = event->x + view->scroll_x;
+		view->adding_annot_info.stop.y = event->y + view->scroll_y;
+		g_signal_emit (view, signals[SIGNAL_ANNOT_ADDED], 0, view->adding_annot_info.annot);
+
+		view->adding_annot_info.adding_annot = FALSE;
+		view->adding_annot_info.annot = NULL;
 		ev_view_handle_cursor_over_xy (view, event->x, event->y);
 		view->pressed_button = -1;
-
-		ev_view_create_annotation (view,
-					   view->adding_annot_type,
-					   event->x + view->scroll_x,
-					   event->y + view->scroll_y);
 
 		return FALSE;
 	}

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -35,6 +35,7 @@ libview/ev-view-presentation.c
 libview/ev-view.c
 shell/eggfindbar.c
 shell/ev-annotation-properties-dialog.c
+shell/ev-annotations-toolbar.c
 shell/ev-application.c
 shell/ev-history.c
 shell/ev-history-action.c

--- a/shell/ev-annotation-properties-dialog.c
+++ b/shell/ev-annotation-properties-dialog.c
@@ -44,6 +44,9 @@ struct _EvAnnotationPropertiesDialog {
 
 	/* Text Annotations */
 	GtkWidget       *icon;
+
+        /* Text Markup Annotations */
+        GtkWidget       *text_markup_type;
 };
 
 struct _EvAnnotationPropertiesDialogClass {
@@ -118,6 +121,22 @@ ev_annotation_properties_dialog_constructed (GObject *object)
 		break;
 	case EV_ANNOTATION_TYPE_ATTACHMENT:
 		/* TODO */
+                break;
+        case EV_ANNOTATION_TYPE_TEXT_MARKUP:
+                label = gtk_label_new (_("Markup type:"));
+                gtk_misc_set_alignment (GTK_MISC (label), 0., 0.5);
+                gtk_grid_attach (GTK_GRID (grid), label, 0, 5, 1, 1);
+                gtk_widget_show (label);
+
+                dialog->text_markup_type = gtk_combo_box_text_new ();
+                gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (dialog->text_markup_type), _("Highlight"));
+                gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (dialog->text_markup_type), _("Strike out"));
+                gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (dialog->text_markup_type), _("Underline"));
+                gtk_combo_box_set_active (GTK_COMBO_BOX (dialog->text_markup_type), 0);
+                gtk_grid_attach (GTK_GRID (grid), dialog->text_markup_type, 1, 5, 1, 1);
+                gtk_widget_set_hexpand (dialog->text_markup_type, TRUE);
+                gtk_widget_show (dialog->text_markup_type);
+                break;
 	default:
 		break;
 	}
@@ -287,7 +306,12 @@ ev_annotation_properties_dialog_new_with_annotation (EvAnnotation *annot)
 
 		gtk_combo_box_set_active (GTK_COMBO_BOX (dialog->icon),
 					  ev_annotation_text_get_icon (annot_text));
-	}
+	} else if (EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
+                EvAnnotationTextMarkup *annot_markup = EV_ANNOTATION_TEXT_MARKUP (annot);
+
+                gtk_combo_box_set_active (GTK_COMBO_BOX (dialog->text_markup_type),
+                                          ev_annotation_text_markup_get_markup_type (annot_markup));
+        }
 
 	return GTK_WIDGET (dialog);
 }
@@ -321,4 +345,10 @@ EvAnnotationTextIcon
 ev_annotation_properties_dialog_get_text_icon (EvAnnotationPropertiesDialog *dialog)
 {
 	return gtk_combo_box_get_active (GTK_COMBO_BOX (dialog->icon));
+}
+
+EvAnnotationTextMarkupType
+ev_annotation_properties_dialog_get_text_markup_type (EvAnnotationPropertiesDialog *dialog)
+{
+        return gtk_combo_box_get_active (GTK_COMBO_BOX (dialog->text_markup_type));
 }

--- a/shell/ev-annotation-properties-dialog.c
+++ b/shell/ev-annotation-properties-dialog.c
@@ -132,6 +132,7 @@ ev_annotation_properties_dialog_constructed (GObject *object)
                 gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (dialog->text_markup_type), _("Highlight"));
                 gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (dialog->text_markup_type), _("Strike out"));
                 gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (dialog->text_markup_type), _("Underline"));
+                gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (dialog->text_markup_type), _("Squiggly"));
                 gtk_combo_box_set_active (GTK_COMBO_BOX (dialog->text_markup_type), 0);
                 gtk_grid_attach (GTK_GRID (grid), dialog->text_markup_type, 1, 5, 1, 1);
                 gtk_widget_set_hexpand (dialog->text_markup_type, TRUE);

--- a/shell/ev-annotation-properties-dialog.h
+++ b/shell/ev-annotation-properties-dialog.h
@@ -38,16 +38,17 @@ G_BEGIN_DECLS
 typedef struct _EvAnnotationPropertiesDialog      EvAnnotationPropertiesDialog;
 typedef struct _EvAnnotationPropertiesDialogClass EvAnnotationPropertiesDialogClass;
 
-GType                ev_annotation_properties_dialog_get_type            (void) G_GNUC_CONST;
-GtkWidget           *ev_annotation_properties_dialog_new                 (EvAnnotationType              annot_type);
-GtkWidget           *ev_annotation_properties_dialog_new_with_annotation (EvAnnotation                 *annot);
+GType                      ev_annotation_properties_dialog_get_type             (void) G_GNUC_CONST;
+GtkWidget                 *ev_annotation_properties_dialog_new                  (EvAnnotationType              annot_type);
+GtkWidget                 *ev_annotation_properties_dialog_new_with_annotation  (EvAnnotation                 *annot);
 
-const gchar         *ev_annotation_properties_dialog_get_author          (EvAnnotationPropertiesDialog *dialog);
-void                 ev_annotation_properties_dialog_get_rgba            (EvAnnotationPropertiesDialog *dialog,
-									  GdkRGBA                      *rgba);
-gdouble              ev_annotation_properties_dialog_get_opacity         (EvAnnotationPropertiesDialog *dialog);
-gboolean             ev_annotation_properties_dialog_get_popup_is_open   (EvAnnotationPropertiesDialog *dialog);
-EvAnnotationTextIcon ev_annotation_properties_dialog_get_text_icon       (EvAnnotationPropertiesDialog *dialog);
+const gchar               *ev_annotation_properties_dialog_get_author           (EvAnnotationPropertiesDialog *dialog);
+void                       ev_annotation_properties_dialog_get_rgba             (EvAnnotationPropertiesDialog *dialog,
+                                                                                 GdkRGBA                      *rgba);
+gdouble                    ev_annotation_properties_dialog_get_opacity          (EvAnnotationPropertiesDialog *dialog);
+gboolean                   ev_annotation_properties_dialog_get_popup_is_open    (EvAnnotationPropertiesDialog *dialog);
+EvAnnotationTextIcon       ev_annotation_properties_dialog_get_text_icon        (EvAnnotationPropertiesDialog *dialog);
+EvAnnotationTextMarkupType ev_annotation_properties_dialog_get_text_markup_type (EvAnnotationPropertiesDialog *dialog);
 
 G_END_DECLS
 

--- a/shell/ev-annotations-toolbar.c
+++ b/shell/ev-annotations-toolbar.c
@@ -1,0 +1,173 @@
+/* ev-annotations-toolbar.c
+ *  this file is part of evince, a gnome document viewer
+ *
+ * Copyright (C) 2015 Carlos Garcia Campos  <carlosgc@gnome.org>
+ *
+ * Evince is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Evince is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "ev-annotations-toolbar.h"
+#include <xreader-document.h>
+#include <glib/gi18n.h>
+
+enum {
+        BEGIN_ADD_ANNOT,
+        CANCEL_ADD_ANNOT,
+        N_SIGNALS
+};
+
+struct _EvAnnotationsToolbar {
+	GtkToolbar base_instance;
+
+        GtkWidget *text_button;
+        GtkWidget *highlight_button;
+};
+
+struct _EvAnnotationsToolbarClass {
+	GtkToolbarClass base_class;
+
+};
+
+static guint signals[N_SIGNALS];
+
+G_DEFINE_TYPE (EvAnnotationsToolbar, ev_annotations_toolbar, GTK_TYPE_TOOLBAR)
+
+static void
+ev_annotations_toolbar_annot_button_toggled (GtkWidget            *button,
+                                             EvAnnotationsToolbar *toolbar)
+{
+        EvAnnotationType annot_type;
+
+        if (!gtk_toggle_tool_button_get_active (GTK_TOGGLE_TOOL_BUTTON (button))) {
+                g_signal_emit (toolbar, signals[CANCEL_ADD_ANNOT], 0, NULL);
+                return;
+        }
+
+        if (button == toolbar->text_button) {
+                annot_type = EV_ANNOTATION_TYPE_TEXT;
+                gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (toolbar->highlight_button), FALSE);
+        } else if (button == toolbar->highlight_button) {
+                annot_type = EV_ANNOTATION_TYPE_TEXT_MARKUP;
+                gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (toolbar->text_button), FALSE);
+        } else {
+                g_assert_not_reached ();
+        }
+
+        g_signal_emit (toolbar, signals[BEGIN_ADD_ANNOT], 0, annot_type);
+}
+
+static gboolean
+ev_annotations_toolbar_toggle_button_if_active (EvAnnotationsToolbar *toolbar,
+                                                GtkToggleToolButton  *button)
+{
+        if (!gtk_toggle_tool_button_get_active (button))
+                return FALSE;
+
+        g_signal_handlers_block_by_func (button,
+                                         ev_annotations_toolbar_annot_button_toggled,
+                                         toolbar);
+        gtk_toggle_tool_button_set_active (button, FALSE);
+        g_signal_handlers_unblock_by_func (button,
+                                           ev_annotations_toolbar_annot_button_toggled,
+                                           toolbar);
+
+        return TRUE;
+}
+
+static GtkWidget *
+ev_annotations_toolbar_create_toggle_button (EvAnnotationsToolbar *toolbar,
+                                             const gchar          *icon_name,
+                                             const gchar          *tooltip)
+{
+        GtkWidget *button = GTK_WIDGET (gtk_toggle_tool_button_new ());
+
+        gtk_widget_set_tooltip_text (button, tooltip);
+        gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON (button), icon_name);
+        /* For some reason adding text-button class to the GtkToogleButton makes the button smaller */
+        gtk_style_context_add_class (gtk_widget_get_style_context (gtk_bin_get_child (GTK_BIN (button))), "text-button");
+        g_signal_connect (button, "toggled",
+                          G_CALLBACK (ev_annotations_toolbar_annot_button_toggled),
+                          toolbar);
+
+        return button;
+}
+
+static void
+ev_annotations_toolbar_init (EvAnnotationsToolbar *toolbar)
+{
+        gtk_orientable_set_orientation (GTK_ORIENTABLE (toolbar), GTK_ORIENTATION_HORIZONTAL);
+
+        gtk_toolbar_set_icon_size (GTK_TOOLBAR (toolbar), GTK_ICON_SIZE_MENU);
+        gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (toolbar)),
+                                     GTK_STYLE_CLASS_INLINE_TOOLBAR);
+
+        toolbar->text_button = ev_annotations_toolbar_create_toggle_button (toolbar,
+                                                                            "document-new-symbolic",
+                                                                            _("Add text annotation"));
+        gtk_container_add (GTK_CONTAINER(toolbar), toolbar->text_button);
+        gtk_widget_show (toolbar->text_button);
+
+        /* FIXME: use a better icon than select-all */
+        toolbar->highlight_button = ev_annotations_toolbar_create_toggle_button (toolbar,
+                                                                                 "edit-select-all-symbolic",
+                                                                                 _("Add highlight annotation"));
+        gtk_container_add (GTK_CONTAINER (toolbar), toolbar->highlight_button);
+        gtk_widget_show (toolbar->highlight_button);
+}
+
+static void
+ev_annotations_toolbar_class_init (EvAnnotationsToolbarClass *klass)
+{
+        GObjectClass *g_object_class = G_OBJECT_CLASS (klass);
+
+        signals[BEGIN_ADD_ANNOT] =
+                g_signal_new ("begin-add-annot",
+                              G_TYPE_FROM_CLASS (g_object_class),
+                              G_SIGNAL_RUN_LAST,
+                              0,
+                              NULL, NULL,
+                              g_cclosure_marshal_VOID__ENUM,
+                              G_TYPE_NONE, 1,
+                              EV_TYPE_ANNOTATION_TYPE);
+
+        signals[CANCEL_ADD_ANNOT] =
+                g_signal_new ("cancel-add-annot",
+                              G_TYPE_FROM_CLASS (g_object_class),
+                              G_SIGNAL_RUN_LAST,
+                              0,
+                              NULL, NULL,
+                              g_cclosure_marshal_VOID__VOID,
+                              G_TYPE_NONE, 0,
+                              G_TYPE_NONE);
+}
+
+GtkWidget *
+ev_annotations_toolbar_new (void)
+{
+	return GTK_WIDGET (g_object_new (EV_TYPE_ANNOTATIONS_TOOLBAR, NULL));
+}
+
+void
+ev_annotations_toolbar_add_annot_finished (EvAnnotationsToolbar *toolbar)
+{
+        g_return_if_fail (EV_IS_ANNOTATIONS_TOOLBAR (toolbar));
+
+        if (ev_annotations_toolbar_toggle_button_if_active (toolbar, GTK_TOGGLE_TOOL_BUTTON (toolbar->text_button)))
+                return;
+
+        ev_annotations_toolbar_toggle_button_if_active (toolbar, GTK_TOGGLE_TOOL_BUTTON (toolbar->highlight_button));
+}

--- a/shell/ev-annotations-toolbar.h
+++ b/shell/ev-annotations-toolbar.h
@@ -1,0 +1,44 @@
+/* ev-annotations-toolbar.h
+ *  this file is part of evince, a gnome document viewer
+ *
+ * Copyright (C) 2015 Carlos Garcia Campos  <carlosgc@gnome.org>
+ *
+ * Evince is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Evince is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef __EV_ANNOTATIONS_TOOLBAR_H__
+#define __EV_ANNOTATIONS_TOOLBAR_H__
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+#define EV_TYPE_ANNOTATIONS_TOOLBAR              (ev_annotations_toolbar_get_type())
+#define EV_ANNOTATIONS_TOOLBAR(object)           (G_TYPE_CHECK_INSTANCE_CAST((object), EV_TYPE_ANNOTATIONS_TOOLBAR, EvAnnotationsToolbar))
+#define EV_IS_ANNOTATIONS_TOOLBAR(object)        (G_TYPE_CHECK_INSTANCE_TYPE((object), EV_TYPE_ANNOTATIONS_TOOLBAR))
+#define EV_ANNOTATIONS_TOOLBAR_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST((klass), EV_TYPE_ANNOTATIONS_TOOLBAR, EvAnnotationsToolbarClass))
+#define EV_IS_ANNOTATIONS_TOOLBAR_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE((klass), EV_TYPE_ANNOTATIONS_TOOLBAR))
+#define EV_ANNOTATIONS_TOOLBAR_GET_CLASS(object) (G_TYPE_INSTANCE_GET_CLASS((object), EV_TYPE_ANNOTATIONS_TOOLBAR, EvAnnotationsToolbarClass))
+
+typedef struct _EvAnnotationsToolbar        EvAnnotationsToolbar;
+typedef struct _EvAnnotationsToolbarClass   EvAnnotationsToolbarClass;
+
+GType      ev_annotations_toolbar_get_type           (void) G_GNUC_CONST;
+GtkWidget *ev_annotations_toolbar_new                (void);
+void       ev_annotations_toolbar_add_annot_finished (EvAnnotationsToolbar *toolbar);
+
+G_END_DECLS
+
+#endif /* __EV_ANNOTATIONS_TOOLBAR_H__ */

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -326,6 +326,7 @@ job_finished_callback (EvJobAnnots          *job,
         GdkPixbuf *highlight_icon = NULL;
         GdkPixbuf *strike_out_icon = NULL;
         GdkPixbuf *underline_icon = NULL;
+        GdkPixbuf *squiggly_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -443,6 +444,14 @@ job_finished_callback (EvJobAnnots          *job,
                                         }
                                         pixbuf = underline_icon;
                                         break;
+                                case EV_ANNOTATION_TEXT_MARKUP_SQUIGGLY:
+                                        if (!squiggly_icon) {
+                                                squiggly_icon = gtk_widget_render_icon_pixbuf (priv->tree_view,
+                                                                                               GTK_STOCK_UNDERLINE,
+                                                                                               GTK_ICON_SIZE_BUTTON);
+                                        }
+                                        pixbuf = squiggly_icon;
+                                        break;
                                 }
                         }
 
@@ -474,6 +483,8 @@ job_finished_callback (EvJobAnnots          *job,
                 g_object_unref (strike_out_icon);
         if (underline_icon)
                 g_object_unref (underline_icon);
+        if (squiggly_icon)
+                g_object_unref (squiggly_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -123,8 +123,6 @@ ev_sidebar_annotations_init (EvSidebarAnnotations *ev_annots)
 	GtkWidget *toolbar;
 	GtkWidget *toolitem;
 	GtkWidget *hbox;
-	GtkWidget *image;
-
 
 	ev_annots->priv = EV_SIDEBAR_ANNOTATIONS_GET_PRIVATE (ev_annots);
 
@@ -251,7 +249,7 @@ EvAnnotationsToolbar *
 ev_sidebar_annotations_get_toolbar(EvSidebarAnnotations *sidebar_annots)
 {
 	EvSidebarAnnotationsPrivate *priv = EV_SIDEBAR_ANNOTATIONS_GET_PRIVATE(sidebar_annots);
-	return priv->toolbar;
+	return EV_ANNOTATIONS_TOOLBAR(priv->toolbar);
 }
 
 
@@ -479,7 +477,6 @@ ev_sidebar_annotations_document_changed_cb (EvDocumentModel      *model,
 {
 	EvDocument *document = ev_document_model_get_document (model);
 	EvSidebarAnnotationsPrivate *priv = sidebar_annots->priv;
-	gboolean enable_add;
 
 	if (!EV_IS_DOCUMENT_ANNOTATIONS (document))
 		return;
@@ -488,7 +485,7 @@ ev_sidebar_annotations_document_changed_cb (EvDocumentModel      *model,
 		g_object_unref (priv->document);
 	priv->document = g_object_ref (document);
 
-	enable_add = ev_document_annotations_can_add_annotation (EV_DOCUMENT_ANNOTATIONS (document));
+	ev_document_annotations_can_add_annotation (EV_DOCUMENT_ANNOTATIONS (document));
 
 	ev_sidebar_annotations_load (sidebar_annots);
 }

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -324,6 +324,7 @@ job_finished_callback (EvJobAnnots          *job,
 	GdkPixbuf *text_icon = NULL;
 	GdkPixbuf *attachment_icon = NULL;
         GdkPixbuf *highlight_icon = NULL;
+        GdkPixbuf *strike_out_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -414,13 +415,26 @@ job_finished_callback (EvJobAnnots          *job,
 				}
 				pixbuf = attachment_icon;
 			} else if (EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
-                                if (!highlight_icon) {
-                                        /* FIXME: use better icon than select all */
-                                        highlight_icon = gtk_widget_render_icon_pixbuf (priv->tree_view,
-                                                                                        GTK_STOCK_SELECT_ALL,
-                                                                                        GTK_ICON_SIZE_BUTTON);
+                                switch (ev_annotation_text_markup_get_markup_type (EV_ANNOTATION_TEXT_MARKUP (annot))) {
+                                case EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT:
+                                        if (!highlight_icon) {
+                                                /* FIXME: use better icon than select all */
+                                                highlight_icon = gtk_widget_render_icon_pixbuf (priv->tree_view,
+                                                                                                GTK_STOCK_SELECT_ALL,
+                                                                                                GTK_ICON_SIZE_BUTTON);
+                                        }
+                                        pixbuf = highlight_icon;
+
+                                        break;
+                                case EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT:
+                                        if (!strike_out_icon) {
+                                                strike_out_icon = gtk_widget_render_icon_pixbuf (priv->tree_view,
+                                                                                                 GTK_STOCK_STRIKETHROUGH,
+                                                                                                 GTK_ICON_SIZE_BUTTON);
+                                        }
+                                        pixbuf = strike_out_icon;
+                                        break;
                                 }
-                                pixbuf = highlight_icon;
                         }
 
 			gtk_tree_store_append (model, &child_iter, &iter);
@@ -447,6 +461,8 @@ job_finished_callback (EvJobAnnots          *job,
 		g_object_unref (attachment_icon);
         if (highlight_icon)
                 g_object_unref (highlight_icon);
+        if (strike_out_icon)
+                g_object_unref (strike_out_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -325,6 +325,7 @@ job_finished_callback (EvJobAnnots          *job,
 	GdkPixbuf *attachment_icon = NULL;
         GdkPixbuf *highlight_icon = NULL;
         GdkPixbuf *strike_out_icon = NULL;
+        GdkPixbuf *underline_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -434,6 +435,14 @@ job_finished_callback (EvJobAnnots          *job,
                                         }
                                         pixbuf = strike_out_icon;
                                         break;
+                                case EV_ANNOTATION_TEXT_MARKUP_UNDERLINE:
+                                        if (!underline_icon) {
+                                                underline_icon = gtk_widget_render_icon_pixbuf (priv->tree_view,
+                                                                                                GTK_STOCK_UNDERLINE,
+                                                                                                GTK_ICON_SIZE_BUTTON);
+                                        }
+                                        pixbuf = underline_icon;
+                                        break;
                                 }
                         }
 
@@ -463,6 +472,8 @@ job_finished_callback (EvJobAnnots          *job,
                 g_object_unref (highlight_icon);
         if (strike_out_icon)
                 g_object_unref (strike_out_icon);
+        if (underline_icon)
+                g_object_unref (underline_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -323,6 +323,7 @@ job_finished_callback (EvJobAnnots          *job,
 	GdkScreen *screen;
 	GdkPixbuf *text_icon = NULL;
 	GdkPixbuf *attachment_icon = NULL;
+        GdkPixbuf *highlight_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -412,7 +413,15 @@ job_finished_callback (EvJobAnnots          *job,
 																NULL);
 				}
 				pixbuf = attachment_icon;
-			}
+			} else if (EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
+                                if (!highlight_icon) {
+                                        /* FIXME: use better icon than select all */
+                                        highlight_icon = gtk_widget_render_icon_pixbuf (priv->tree_view,
+                                                                                        GTK_STOCK_SELECT_ALL,
+                                                                                        GTK_ICON_SIZE_BUTTON);
+                                }
+                                pixbuf = highlight_icon;
+                        }
 
 			gtk_tree_store_append (model, &child_iter, &iter);
 			gtk_tree_store_set (model, &child_iter,
@@ -436,6 +445,8 @@ job_finished_callback (EvJobAnnots          *job,
 		g_object_unref (text_icon);
 	if (attachment_icon)
 		g_object_unref (attachment_icon);
+        if (highlight_icon)
+                g_object_unref (highlight_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -1,5 +1,5 @@
 /* ev-sidebar-annotations.c
- *  this file is part of xreader, a mate document viewer
+ *  this file is part of xreader, a generic document viewer
  *
  * Copyright (C) 2010 Carlos Garcia Campos  <carlosgc@gnome.org>
  *
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include "config.h"
@@ -53,7 +53,9 @@ struct _EvSidebarAnnotationsPrivate {
 
 	GtkWidget *notebook;
 	GtkWidget *tree_view;
-	GtkWidget *annot_text_item;
+	GtkWidget   *palette;
+	GtkToolItem *annot_text_item;
+	GtkToolItem *annot_highlight_item;
 
 	EvJob *job;
 	guint selection_changed_id;
@@ -132,6 +134,26 @@ ev_sidebar_annotations_text_annot_button_toggled (GtkWidget  *button,
 }
 
 static void
+ev_sidebar_annotations_highlight_annot_button_toggled (GtkWidget  *button,
+						  EvSidebarAnnotations *sidebar_annots)
+{
+	EvAnnotationType annot_type;
+
+	if (!gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (button))) {
+		g_signal_emit (sidebar_annots, signals[ANNOT_ADD_CANCELLED], 0, NULL);
+		return;
+	}
+
+	if (button == sidebar_annots->priv->annot_highlight_item)
+		annot_type = EV_ANNOTATION_TYPE_TEXT_MARKUP;
+	else
+		annot_type = EV_ANNOTATION_TYPE_UNKNOWN;
+
+	g_signal_emit (sidebar_annots, signals[BEGIN_ANNOT_ADD], 0, annot_type);
+}
+
+
+static void
 ev_sidebar_annotations_init (EvSidebarAnnotations *ev_annots)
 {
 	GtkWidget *swindow;
@@ -196,17 +218,34 @@ ev_sidebar_annotations_init (EvSidebarAnnotations *ev_annots)
 	gtk_container_add (GTK_CONTAINER (toolitem), hbox);
 	gtk_widget_show (hbox);
 
+	/* Note annotation button */
 	ev_annots->priv->annot_text_item = gtk_toggle_button_new ();
-	image = gtk_image_new_from_icon_name ("list-add-symbolic", GTK_ICON_SIZE_BUTTON);
+	image = gtk_image_new_from_icon_name ("document-new", GTK_ICON_SIZE_BUTTON);
+	//gtk_tool_button_set_icon_widget(GTK_TOOL_BUTTON(ev_annots->priv->annot_text_item), image);
 	gtk_container_add (GTK_CONTAINER (ev_annots->priv->annot_text_item), image);
 	gtk_widget_show (image);
 
 	gtk_box_pack_start (GTK_BOX (hbox), ev_annots->priv->annot_text_item, FALSE, FALSE, 0);
-	gtk_widget_set_tooltip_text (GTK_WIDGET (ev_annots->priv->annot_text_item), _("Add text annotation"));
+	// gtk_toolbar_insert(GTK_TOOLBAR(toolbar), GTK_TOOL_ITEM(ev_annots->priv->annot_text_item), 0);
+	gtk_widget_set_tooltip_text (GTK_WIDGET (ev_annots->priv->annot_text_item), _("Add a note annotation"));
 	g_signal_connect (ev_annots->priv->annot_text_item, "toggled",
 			  G_CALLBACK (ev_sidebar_annotations_text_annot_button_toggled),
 			  ev_annots);
 	gtk_widget_show (GTK_WIDGET (ev_annots->priv->annot_text_item));
+
+	/* Highlight annotation button */
+	ev_annots->priv->annot_highlight_item = gtk_toggle_button_new ();
+	image = gtk_image_new_from_icon_name ("edit-select-all", GTK_ICON_SIZE_BUTTON);
+	gtk_container_add (GTK_CONTAINER (ev_annots->priv->annot_highlight_item), image);
+	gtk_widget_show (image);
+
+	gtk_box_pack_start (GTK_BOX (hbox), ev_annots->priv->annot_highlight_item, FALSE, FALSE, 0);
+	gtk_widget_set_tooltip_text (GTK_WIDGET (ev_annots->priv->annot_highlight_item), _("Add text annotation"));
+	g_signal_connect (ev_annots->priv->annot_highlight_item, "toggled",
+			  G_CALLBACK (ev_sidebar_annotations_highlight_annot_button_toggled),
+			  ev_annots);
+	gtk_widget_show (GTK_WIDGET (ev_annots->priv->annot_highlight_item));
+
 
 	gtk_box_pack_end (GTK_BOX (ev_annots), toolbar, FALSE, TRUE, 0);
 	gtk_widget_show (GTK_WIDGET (ev_annots));

--- a/shell/ev-sidebar-annotations.h
+++ b/shell/ev-sidebar-annotations.h
@@ -24,6 +24,8 @@
 #include <gtk/gtk.h>
 #include <glib-object.h>
 
+#include "ev-annotations-toolbar.h"
+
 G_BEGIN_DECLS
 
 typedef struct _EvSidebarAnnotations        EvSidebarAnnotations;
@@ -48,9 +50,6 @@ struct _EvSidebarAnnotationsClass {
 
 	void    (* annot_activated)     (EvSidebarAnnotations *sidebar_annots,
 					 EvMapping            *mapping);
-	void    (* begin_annot_add)     (EvSidebarAnnotations *sidebar_annots,
-					 EvAnnotationType      annot_type);
-	void    (* annot_add_cancelled) (EvSidebarAnnotations *sidebar_annots);
 };
 
 GType      ev_sidebar_annotations_get_type    (void) G_GNUC_CONST;
@@ -59,6 +58,8 @@ void       ev_sidebar_annotations_annot_added (EvSidebarAnnotations *sidebar_ann
 					       EvAnnotation         *annot);
 void       ev_sidebar_annotations_annot_removed (EvSidebarAnnotations *sidebar_annots,
 					       EvAnnotation         *annot);
+EvAnnotationsToolbar *ev_sidebar_annotations_get_toolbar(EvSidebarAnnotations *sidebar_annots);
+
 G_END_DECLS
 
 #endif /* __EV_SIDEBAR_ANNOTATIONS_H__ */

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -7014,6 +7014,14 @@ ev_view_popup_cmd_annot_properties (GtkAction *action,
             mask |= EV_ANNOTATIONS_SAVE_TEXT_ICON;
     }
 
+	if (EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
+		EvAnnotationTextMarkupType markup_type;
+
+		markup_type = ev_annotation_properties_dialog_get_text_markup_type (dialog);
+		if (ev_annotation_text_markup_set_markup_type (EV_ANNOTATION_TEXT_MARKUP (annot), markup_type))
+			mask |= EV_ANNOTATIONS_SAVE_TEXT_MARKUP_TYPE;
+	}
+
     if (mask != EV_ANNOTATIONS_SAVE_NONE) {
         ev_document_doc_mutex_lock ();
         ev_document_annotations_save_annotation (EV_DOCUMENT_ANNOTATIONS (window->priv->document),

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -3,6 +3,8 @@ shell_sources = [
     'eggfindbar.h',
     'ev-annotation-properties-dialog.h',
     'ev-annotation-properties-dialog.c',
+    'ev-annotations-toolbar.h',
+    'ev-annotations-toolbar.c',
     'ev-bookmarks.h',
     'ev-bookmarks.c',
     'ev-bookmark-action.h',


### PR DESCRIPTION
This PR is based on @mickaelalbertus work within PR#223. It adds new text markup annotations. Currently squiggly, underline, strike-out and a feature to switch between those. A button to add new ones is now beneath the annotation list inside the sidebar. It is also possible to remove annotations.

**UPDATED**