### PR TITLE
Epub thumbnailer segfault

### DIFF
--- a/thumbnailer/xreader-thumbnailer.c
+++ b/thumbnailer/xreader-thumbnailer.c
@@ -247,7 +247,7 @@ main (int argc, char *argv[])
 	GFile          *file;
 	GError         *error = NULL;
 
-	context = g_option_context_new ("- MATE Document Thumbnailer");
+	context = g_option_context_new ("- Document Thumbnailer");
 	g_option_context_add_main_entries (context, goption_options, NULL);
 
 	if (!g_option_context_parse (context, &argc, &argv, &error)) {

--- a/thumbnailer/xreader-thumbnailer.c
+++ b/thumbnailer/xreader-thumbnailer.c
@@ -290,7 +290,7 @@ main (int argc, char *argv[])
 		return -2;
 	}
 
-	if (!EV_IS_DOCUMENT_THUMBNAILS (document)) {
+	if (!EV_IS_DOCUMENT_THUMBNAILS (document) || document->iswebdocument) {
 		g_object_unref (document);
 		ev_shutdown ();
 		return -2;


### PR DESCRIPTION
Do not try to create an EPUB thumbnail, because it will segfault. Better exit gracefully with errorcode -2. The proper epub thumbnail creation will then be in #340 for next cycle

Fixes #332