### PR TITLE
Remove use of deprecated g_type_class_add_private function

### DIFF
--- a/cut-n-paste/smclient/eggsmclient.c
+++ b/cut-n-paste/smclient/eggsmclient.c
@@ -46,9 +46,8 @@ struct _EggSMClientPrivate {
   GKeyFile *state_file;
 };
 
-#define EGG_SM_CLIENT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), EGG_TYPE_SM_CLIENT, EggSMClientPrivate))
 
-G_DEFINE_TYPE (EggSMClient, egg_sm_client, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EggSMClient, egg_sm_client, G_TYPE_OBJECT)
 
 static EggSMClient *global_client;
 static EggSMClientMode global_client_mode = EGG_SM_CLIENT_MODE_NORMAL;
@@ -63,8 +62,6 @@ static void
 egg_sm_client_class_init (EggSMClientClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (EggSMClientPrivate));
 
   /**
    * EggSMClient::save_state:
@@ -376,7 +373,7 @@ egg_sm_client_is_resumed (EggSMClient *client)
 GKeyFile *
 egg_sm_client_get_state_file (EggSMClient *client)
 {
-  EggSMClientPrivate *priv = EGG_SM_CLIENT_GET_PRIVATE (client);
+  EggSMClientPrivate *priv = egg_sm_client_get_instance_private (client);
   char *state_file_path;
   GError *err = NULL;
 

--- a/cut-n-paste/totem-screensaver/totem-scrsaver.c
+++ b/cut-n-paste/totem-screensaver/totem-scrsaver.c
@@ -77,7 +77,7 @@ struct TotemScrsaverPrivate {
 	gboolean have_xtest;
 };
 
-G_DEFINE_TYPE(TotemScrsaver, totem_scrsaver, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE(TotemScrsaver, totem_scrsaver, G_TYPE_OBJECT)
 
 static gboolean
 screensaver_is_running_dbus (TotemScrsaver *scr)
@@ -448,8 +448,6 @@ totem_scrsaver_class_init (TotemScrsaverClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-	g_type_class_add_private (klass, sizeof (TotemScrsaverPrivate));
-
 	object_class->set_property = totem_scrsaver_set_property;
 	object_class->get_property = totem_scrsaver_get_property;
 	object_class->finalize = totem_scrsaver_finalize;
@@ -479,9 +477,7 @@ totem_scrsaver_new (void)
 static void
 totem_scrsaver_init (TotemScrsaver *scr)
 {
-	scr->priv = G_TYPE_INSTANCE_GET_PRIVATE (scr,
-						 TOTEM_TYPE_SCRSAVER,
-						 TotemScrsaverPrivate);
+	scr->priv = totem_scrsaver_get_instance_private  (scr);
 
 	screensaver_init_dbus (scr);
 #ifdef GDK_WINDOWING_X11

--- a/cut-n-paste/zoom-control/ephy-zoom-action.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-action.c
@@ -31,8 +31,6 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#define EPHY_ZOOM_ACTION_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), EPHY_TYPE_ZOOM_ACTION, EphyZoomActionPrivate))
-
 struct _EphyZoomActionPrivate
 {
 	float zoom;
@@ -60,7 +58,7 @@ enum
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-G_DEFINE_TYPE (EphyZoomAction, ephy_zoom_action, GTK_TYPE_ACTION)
+G_DEFINE_TYPE_WITH_PRIVATE (EphyZoomAction, ephy_zoom_action, GTK_TYPE_ACTION)
 
 static void
 zoom_to_level_cb (EphyZoomControl *control,
@@ -274,14 +272,12 @@ ephy_zoom_action_class_init (EphyZoomActionClass *class)
 			      G_TYPE_NONE,
 			      1,
 			      G_TYPE_FLOAT);
-
-	g_type_class_add_private (object_class, sizeof (EphyZoomActionPrivate));
 }
 
 static void
 ephy_zoom_action_init (EphyZoomAction *action)
 {
-	action->priv = EPHY_ZOOM_ACTION_GET_PRIVATE (action);
+	action->priv = ephy_zoom_action_get_instance_private (action);
 
 	action->priv->zoom = 1.0;
 }

--- a/cut-n-paste/zoom-control/ephy-zoom-control.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-control.c
@@ -28,9 +28,6 @@
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 
-#define EPHY_ZOOM_CONTROL_GET_PRIVATE(object)\
-	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EPHY_TYPE_ZOOM_CONTROL, EphyZoomControlPrivate))
-
 struct _EphyZoomControlPrivate
 {
 	GtkComboBox *combo;
@@ -62,7 +59,7 @@ enum
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-G_DEFINE_TYPE (EphyZoomControl, ephy_zoom_control, GTK_TYPE_TOOL_ITEM)
+G_DEFINE_TYPE_WITH_PRIVATE (EphyZoomControl, ephy_zoom_control, GTK_TYPE_TOOL_ITEM)
 
 static void
 combo_changed_cb (GtkComboBox *combo, EphyZoomControl *control)
@@ -160,7 +157,7 @@ ephy_zoom_control_init (EphyZoomControl *control)
 	GtkTreeIter      iter;
 	guint i;
 
-	p = EPHY_ZOOM_CONTROL_GET_PRIVATE (control);
+	p = ephy_zoom_control_get_instance_private (control);
 	control->priv = p;
 
 	p->zoom = 1.0;
@@ -324,8 +321,6 @@ ephy_zoom_control_class_init (EphyZoomControlClass *klass)
 			      G_TYPE_NONE,
 			      1,
 			      G_TYPE_FLOAT);
-
-	g_type_class_add_private (object_class, sizeof (EphyZoomControlPrivate));
 }
 
 void

--- a/libdocument/ev-attachment.c
+++ b/libdocument/ev-attachment.c
@@ -48,10 +48,7 @@ struct _EvAttachmentPrivate {
 	GFile                   *tmp_file;
 };
 
-#define EV_ATTACHMENT_GET_PRIVATE(object) \
-                (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_ATTACHMENT, EvAttachmentPrivate))
-
-G_DEFINE_TYPE (EvAttachment, ev_attachment, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EvAttachment, ev_attachment, G_TYPE_OBJECT)
 
 GQuark
 ev_attachment_error_quark (void)
@@ -152,8 +149,6 @@ ev_attachment_class_init (EvAttachmentClass *klass)
 
 	g_object_class->set_property = ev_attachment_set_property;
 
-	g_type_class_add_private (g_object_class, sizeof (EvAttachmentPrivate));
-
 	/* Properties */
 	g_object_class_install_property (g_object_class,
 					 PROP_NAME,
@@ -209,7 +204,7 @@ ev_attachment_class_init (EvAttachmentClass *klass)
 static void
 ev_attachment_init (EvAttachment *attachment)
 {
-	attachment->priv = EV_ATTACHMENT_GET_PRIVATE (attachment);
+	attachment->priv = ev_attachment_get_instance_private (attachment);
 
 	attachment->priv->name = NULL;
 	attachment->priv->description = NULL;

--- a/libdocument/ev-document.c
+++ b/libdocument/ev-document.c
@@ -28,8 +28,6 @@
 #include "synctex_parser.h"
 #include "ev-file-helpers.h"
 
-#define EV_DOCUMENT_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EV_TYPE_DOCUMENT, EvDocumentPrivate))
-
 typedef struct _EvPageSize
 {
 	gdouble width;
@@ -73,7 +71,7 @@ static gboolean        _ev_document_support_synctex (EvDocument *document);
 static GMutex ev_doc_mutex;
 static GMutex ev_fc_mutex;
 
-G_DEFINE_ABSTRACT_TYPE (EvDocument, ev_document, G_TYPE_OBJECT)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (EvDocument, ev_document, G_TYPE_OBJECT)
 
 GQuark
 ev_document_error_quark (void)
@@ -139,7 +137,7 @@ ev_document_finalize (GObject *object)
 static void
 ev_document_init (EvDocument *document)
 {
-	document->priv = EV_DOCUMENT_GET_PRIVATE (document);
+	document->priv = ev_document_get_instance_private (document);
 
 	/* Assume all pages are the same size until proven otherwise */
 	document->priv->uniform = TRUE;
@@ -151,8 +149,6 @@ static void
 ev_document_class_init (EvDocumentClass *klass)
 {
 	GObjectClass *g_object_class = G_OBJECT_CLASS (klass);
-
-	g_type_class_add_private (g_object_class, sizeof (EvDocumentPrivate));
 
 	klass->get_page = ev_document_impl_get_page;
 	klass->get_info = ev_document_impl_get_info;

--- a/libdocument/ev-image.c
+++ b/libdocument/ev-image.c
@@ -33,10 +33,7 @@ struct _EvImagePrivate {
 	gchar     *tmp_uri;
 };
 
-#define EV_IMAGE_GET_PRIVATE(object) \
-                (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_IMAGE, EvImagePrivate))
-
-G_DEFINE_TYPE (EvImage, ev_image, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EvImage, ev_image, G_TYPE_OBJECT)
 
 static void
 ev_image_finalize (GObject *object)
@@ -68,15 +65,13 @@ ev_image_class_init (EvImageClass *klass)
 
 	g_object_class = G_OBJECT_CLASS (klass);
 
-	g_type_class_add_private (g_object_class, sizeof (EvImagePrivate));
-
 	g_object_class->finalize = ev_image_finalize;
 }
 
 static void
 ev_image_init (EvImage *image)
 {
-	image->priv = EV_IMAGE_GET_PRIVATE (image);
+	image->priv = ev_image_get_instance_private (image);
 }
 
 EvImage *

--- a/libdocument/ev-layer.c
+++ b/libdocument/ev-layer.c
@@ -26,23 +26,17 @@ struct _EvLayerPrivate {
 	gint     rb_group;
 };
 
-#define EV_LAYER_GET_PRIVATE(object) \
-                (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_LAYER, EvLayerPrivate))
-
-G_DEFINE_TYPE (EvLayer, ev_layer, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EvLayer, ev_layer, G_TYPE_OBJECT)
 
 static void
 ev_layer_class_init (EvLayerClass *klass)
 {
-	GObjectClass *g_object_class = G_OBJECT_CLASS (klass);
-
-	g_type_class_add_private (g_object_class, sizeof (EvLayerPrivate));
 }
 
 static void
 ev_layer_init (EvLayer *layer)
 {
-	layer->priv = EV_LAYER_GET_PRIVATE (layer);
+	layer->priv = ev_layer_get_instance_private (layer);
 }
 
 EvLayer *

--- a/libdocument/ev-link-action.c
+++ b/libdocument/ev-link-action.c
@@ -57,10 +57,7 @@ struct _EvLinkActionPrivate {
 	GList            *toggle_list;
 };
 
-G_DEFINE_TYPE (EvLinkAction, ev_link_action, G_TYPE_OBJECT)
-
-#define EV_LINK_ACTION_GET_PRIVATE(object) \
-        (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_LINK_ACTION, EvLinkActionPrivate))
+G_DEFINE_TYPE_WITH_PRIVATE (EvLinkAction, ev_link_action, G_TYPE_OBJECT)
 
 EvLinkActionType
 ev_link_action_get_action_type (EvLinkAction *self)
@@ -281,7 +278,7 @@ ev_link_action_finalize (GObject *object)
 static void
 ev_link_action_init (EvLinkAction *ev_link_action)
 {
-	ev_link_action->priv = EV_LINK_ACTION_GET_PRIVATE (ev_link_action);
+	ev_link_action->priv = ev_link_action_get_instance_private (ev_link_action);
 
 	ev_link_action->priv->dest = NULL;
 	ev_link_action->priv->uri = NULL;
@@ -301,8 +298,6 @@ ev_link_action_class_init (EvLinkActionClass *ev_link_action_class)
 	g_object_class->get_property = ev_link_action_get_property;
 
 	g_object_class->finalize = ev_link_action_finalize;
-
-	g_type_class_add_private (g_object_class, sizeof (EvLinkActionPrivate));
 
 	g_object_class_install_property (g_object_class,
 					 PROP_TYPE,

--- a/libdocument/ev-link-dest.c
+++ b/libdocument/ev-link-dest.c
@@ -66,10 +66,7 @@ struct _EvLinkDestPrivate {
 	gchar	      *page_label;
 };
 
-G_DEFINE_TYPE (EvLinkDest, ev_link_dest, G_TYPE_OBJECT)
-
-#define EV_LINK_DEST_GET_PRIVATE(object) \
-        (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_LINK_DEST, EvLinkDestPrivate))
+G_DEFINE_TYPE_WITH_PRIVATE (EvLinkDest, ev_link_dest, G_TYPE_OBJECT)
 
 EvLinkDestType
 ev_link_dest_get_dest_type (EvLinkDest *self)
@@ -273,7 +270,7 @@ ev_link_dest_finalize (GObject *object)
 static void
 ev_link_dest_init (EvLinkDest *ev_link_dest)
 {
-	ev_link_dest->priv = EV_LINK_DEST_GET_PRIVATE (ev_link_dest);
+	ev_link_dest->priv = ev_link_dest_get_instance_private (ev_link_dest);
 
 	ev_link_dest->priv->named = NULL;
 }
@@ -289,8 +286,6 @@ ev_link_dest_class_init (EvLinkDestClass *ev_link_dest_class)
 	g_object_class->get_property = ev_link_dest_get_property;
 
 	g_object_class->finalize = ev_link_dest_finalize;
-
-	g_type_class_add_private (g_object_class, sizeof (EvLinkDestPrivate));
 
 	g_object_class_install_property (g_object_class,
 					 PROP_TYPE,

--- a/libdocument/ev-link.c
+++ b/libdocument/ev-link.c
@@ -41,10 +41,7 @@ struct _EvLinkPrivate {
 	EvLinkAction *action;
 };
 
-G_DEFINE_TYPE (EvLink, ev_link, G_TYPE_OBJECT)
-
-#define EV_LINK_GET_PRIVATE(object) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_LINK, EvLinkPrivate))
+G_DEFINE_TYPE_WITH_PRIVATE (EvLink, ev_link, G_TYPE_OBJECT)
 
 const gchar *
 ev_link_get_title (EvLink *self)
@@ -130,7 +127,7 @@ ev_link_finalize (GObject *object)
 static void
 ev_link_init (EvLink *ev_link)
 {
-	ev_link->priv = EV_LINK_GET_PRIVATE (ev_link);
+	ev_link->priv = ev_link_get_instance_private (ev_link);
 
 	ev_link->priv->title = NULL;
 	ev_link->priv->action = NULL;
@@ -147,8 +144,6 @@ ev_link_class_init (EvLinkClass *ev_window_class)
 	g_object_class->get_property = ev_link_get_property;
 
 	g_object_class->finalize = ev_link_finalize;
-
-	g_type_class_add_private (g_object_class, sizeof (EvLinkPrivate));
 
 	g_object_class_install_property (g_object_class,
 					 PROP_TITLE,

--- a/libdocument/ev-transition-effect.c
+++ b/libdocument/ev-transition-effect.c
@@ -24,8 +24,6 @@
 
 #include "ev-document-type-builtins.h"
 
-#define EV_TRANSITION_EFFECT_GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EV_TYPE_TRANSITION_EFFECT, EvTransitionEffectPrivate))
-
 typedef struct EvTransitionEffectPrivate EvTransitionEffectPrivate;
 
 struct EvTransitionEffectPrivate {
@@ -51,7 +49,7 @@ enum {
 	PROP_RECTANGULAR
 };
 
-G_DEFINE_TYPE (EvTransitionEffect, ev_transition_effect, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EvTransitionEffect, ev_transition_effect, G_TYPE_OBJECT)
 
 static void
 ev_transition_effect_set_property (GObject	*object,
@@ -61,7 +59,7 @@ ev_transition_effect_set_property (GObject	*object,
 {
 	EvTransitionEffectPrivate *priv;
 
-	priv = EV_TRANSITION_EFFECT_GET_PRIV (object);
+	priv = ev_transition_effect_get_instance_private (EV_TRANSITION_EFFECT (object));
 
 	switch (prop_id) {
 	case PROP_TYPE:
@@ -99,7 +97,7 @@ ev_transition_effect_get_property (GObject    *object,
 {
 	EvTransitionEffectPrivate *priv;
 
-	priv = EV_TRANSITION_EFFECT_GET_PRIV (object);
+	priv = ev_transition_effect_get_instance_private (EV_TRANSITION_EFFECT (object));
 
 	switch (prop_id) {
 	case PROP_TYPE:
@@ -134,7 +132,7 @@ ev_transition_effect_init (EvTransitionEffect *effect)
 {
 	EvTransitionEffectPrivate *priv;
 
-	priv = EV_TRANSITION_EFFECT_GET_PRIV (effect);
+	priv = ev_transition_effect_get_instance_private (effect);
 
 	priv->scale = 1.;
 }
@@ -201,7 +199,6 @@ ev_transition_effect_class_init (EvTransitionEffectClass *klass)
 							       FALSE,
 							       G_PARAM_READWRITE));
 
-	g_type_class_add_private (klass, sizeof (EvTransitionEffectPrivate));
 }
 
 EvTransitionEffect *

--- a/libmisc/ev-page-action.c
+++ b/libmisc/ev-page-action.c
@@ -49,9 +49,7 @@ enum
 
 static guint signals[N_SIGNALS] = {0, };
 
-G_DEFINE_TYPE (EvPageAction, ev_page_action, GTK_TYPE_ACTION)
-
-#define EV_PAGE_ACTION_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_PAGE_ACTION, EvPageActionPrivate))
+G_DEFINE_TYPE_WITH_PRIVATE (EvPageAction, ev_page_action, GTK_TYPE_ACTION)
 
 enum {
 	PROP_0,
@@ -201,7 +199,7 @@ ev_page_action_grab_focus (EvPageAction *page_action)
 static void
 ev_page_action_init (EvPageAction *page)
 {
-	page->priv = EV_PAGE_ACTION_GET_PRIVATE (page);
+	page->priv = ev_page_action_get_instance_private (page);
 }
 
 static void
@@ -234,6 +232,4 @@ ev_page_action_class_init (EvPageActionClass *class)
 							      "Current Links Model",
 							      GTK_TYPE_TREE_MODEL,
 							      G_PARAM_READWRITE));
-
-	g_type_class_add_private (object_class, sizeof (EvPageActionPrivate));
 }

--- a/libview/ev-link-accessible.c
+++ b/libview/ev-link-accessible.c
@@ -195,6 +195,7 @@ static void ev_link_accessible_hyperlink_impl_iface_init (AtkHyperlinkImplIface 
 static void ev_link_accessible_action_interface_init     (AtkActionIface        *iface);
 
 G_DEFINE_TYPE_WITH_CODE (EvLinkAccessible, ev_link_accessible, ATK_TYPE_OBJECT,
+			 G_ADD_PRIVATE (EvLinkAccessible)
 			 G_IMPLEMENT_INTERFACE (ATK_TYPE_HYPERLINK_IMPL, ev_link_accessible_hyperlink_impl_iface_init)
 			 G_IMPLEMENT_INTERFACE (ATK_TYPE_ACTION, ev_link_accessible_action_interface_init))
 
@@ -214,14 +215,12 @@ ev_link_accessible_class_init (EvLinkAccessibleClass *klass)
         GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
         object_class->finalize = ev_link_accessible_finalize;
-
-        g_type_class_add_private (klass, sizeof (EvLinkAccessiblePrivate));
 }
 
 static void
 ev_link_accessible_init (EvLinkAccessible *link)
 {
-        link->priv = G_TYPE_INSTANCE_GET_PRIVATE (link, EV_TYPE_LINK_ACCESSIBLE, EvLinkAccessiblePrivate);
+        link->priv = ev_link_accessible_get_instance_private (link);
 }
 
 static AtkHyperlink *

--- a/libview/ev-timeline.c
+++ b/libview/ev-timeline.c
@@ -23,14 +23,13 @@
 #include <math.h>
 #include "ev-timeline.h"
 
-#define EV_TIMELINE_GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EV_TYPE_TIMELINE, EvTimelinePriv))
 #define MSECS_PER_SEC 1000
 #define FRAME_INTERVAL(nframes) (MSECS_PER_SEC / nframes)
 #define DEFAULT_FPS 30
 
-typedef struct EvTimelinePriv EvTimelinePriv;
+typedef struct EvTimelinePrivate EvTimelinePrivate;
 
-struct EvTimelinePriv {
+struct EvTimelinePrivate {
 	guint duration;
 	guint fps;
 	guint source_id;
@@ -58,15 +57,15 @@ enum {
 static guint signals [LAST_SIGNAL] = { 0, };
 
 
-G_DEFINE_TYPE (EvTimeline, ev_timeline, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EvTimeline, ev_timeline, G_TYPE_OBJECT)
 
 
 static void
 ev_timeline_init (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	priv->fps = DEFAULT_FPS;
 	priv->duration = 0;
@@ -103,11 +102,11 @@ ev_timeline_get_property (GObject    *object,
 			  GValue     *value,
 			  GParamSpec *pspec)
 {
-	EvTimeline     *timeline;
-	EvTimelinePriv *priv;
+	EvTimeline        *timeline;
+	EvTimelinePrivate *priv;
 
 	timeline = EV_TIMELINE (object);
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	switch (prop_id) {
 	case PROP_FPS:
@@ -127,9 +126,9 @@ ev_timeline_get_property (GObject    *object,
 static void
 ev_timeline_finalize (GObject *object)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
-	priv = EV_TIMELINE_GET_PRIV (object);
+	priv = ev_timeline_get_instance_private (EV_TIMELINE (object));
 
 	if (priv->source_id) {
 		g_source_remove (priv->source_id);
@@ -145,11 +144,11 @@ ev_timeline_finalize (GObject *object)
 static gboolean
 ev_timeline_run_frame (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
-	gdouble         progress;
-	guint           elapsed_time;
+	EvTimelinePrivate *priv;
+	gdouble            progress;
+	guint              elapsed_time;
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	elapsed_time = (guint) (g_timer_elapsed (priv->timer, NULL) * 1000);
 	progress = (gdouble) elapsed_time / priv->duration;
@@ -177,9 +176,9 @@ ev_timeline_run_frame (EvTimeline *timeline)
 static void
 ev_timeline_real_start (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	if (!priv->source_id) {
 		if (priv->timer)
@@ -270,8 +269,6 @@ ev_timeline_class_init (EvTimelineClass *class)
 			      g_cclosure_marshal_VOID__DOUBLE,
 			      G_TYPE_NONE, 1,
 			      G_TYPE_DOUBLE);
-
-	g_type_class_add_private (class, sizeof (EvTimelinePriv));
 }
 
 EvTimeline *
@@ -293,11 +290,11 @@ ev_timeline_start (EvTimeline *timeline)
 void
 ev_timeline_pause (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_if_fail (EV_IS_TIMELINE (timeline));
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	if (priv->source_id) {
 		g_source_remove (priv->source_id);
@@ -310,11 +307,11 @@ ev_timeline_pause (EvTimeline *timeline)
 void
 ev_timeline_rewind (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_if_fail (EV_IS_TIMELINE (timeline));
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	/* destroy and re-create timer if neccesary  */
 	if (priv->timer) {
@@ -330,11 +327,11 @@ ev_timeline_rewind (EvTimeline *timeline)
 gboolean
 ev_timeline_is_running (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_val_if_fail (EV_IS_TIMELINE (timeline), FALSE);
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	return (priv->source_id != 0);
 }
@@ -342,11 +339,11 @@ ev_timeline_is_running (EvTimeline *timeline)
 guint
 ev_timeline_get_fps (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_val_if_fail (EV_IS_TIMELINE (timeline), 1);
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 	return priv->fps;
 }
 
@@ -354,11 +351,11 @@ void
 ev_timeline_set_fps (EvTimeline *timeline,
 		     guint       fps)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_if_fail (EV_IS_TIMELINE (timeline));
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	priv->fps = fps;
 
@@ -375,11 +372,11 @@ ev_timeline_set_fps (EvTimeline *timeline,
 gboolean
 ev_timeline_get_loop (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_val_if_fail (EV_IS_TIMELINE (timeline), FALSE);
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 	return priv->loop;
 }
 
@@ -387,11 +384,11 @@ void
 ev_timeline_set_loop (EvTimeline *timeline,
 		      gboolean    loop)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_if_fail (EV_IS_TIMELINE (timeline));
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 	priv->loop = loop;
 
 	g_object_notify (G_OBJECT (timeline), "loop");
@@ -401,11 +398,11 @@ void
 ev_timeline_set_duration (EvTimeline *timeline,
 			  guint       duration)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_if_fail (EV_IS_TIMELINE (timeline));
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	priv->duration = duration;
 
@@ -415,11 +412,11 @@ ev_timeline_set_duration (EvTimeline *timeline,
 guint
 ev_timeline_get_duration (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
+	EvTimelinePrivate *priv;
 
 	g_return_val_if_fail (EV_IS_TIMELINE (timeline), 0);
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	return priv->duration;
 }
@@ -427,13 +424,13 @@ ev_timeline_get_duration (EvTimeline *timeline)
 gdouble
 ev_timeline_get_progress (EvTimeline *timeline)
 {
-	EvTimelinePriv *priv;
-	gdouble         progress;
-	guint           elapsed_time;
+	EvTimelinePrivate *priv;
+	gdouble            progress;
+	guint              elapsed_time;
 
 	g_return_val_if_fail (EV_IS_TIMELINE (timeline), 0.0);
 
-	priv = EV_TIMELINE_GET_PRIV (timeline);
+	priv = ev_timeline_get_instance_private (timeline);
 
 	if (!priv->timer)
 		return 0.;

--- a/libview/ev-transition-animation.c
+++ b/libview/ev-transition-animation.c
@@ -24,12 +24,11 @@
 #include "ev-transition-animation.h"
 #include "ev-timeline.h"
 
-#define EV_TRANSITION_ANIMATION_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EV_TYPE_TRANSITION_ANIMATION, EvTransitionAnimationPriv))
 #define N_BLINDS 6
 
-typedef struct EvTransitionAnimationPriv EvTransitionAnimationPriv;
+typedef struct EvTransitionAnimationPrivate EvTransitionAnimationPrivate;
 
-struct EvTransitionAnimationPriv {
+struct EvTransitionAnimationPrivate {
 	EvTransitionEffect *effect;
 	cairo_surface_t *origin_surface;
 	cairo_surface_t *dest_surface;
@@ -43,7 +42,7 @@ enum {
 };
 
 
-G_DEFINE_TYPE (EvTransitionAnimation, ev_transition_animation, EV_TYPE_TIMELINE)
+G_DEFINE_TYPE_WITH_PRIVATE (EvTransitionAnimation, ev_transition_animation, EV_TYPE_TIMELINE)
 
 
 static void
@@ -57,9 +56,9 @@ ev_transition_animation_set_property (GObject      *object,
 				      const GValue *value,
 				      GParamSpec   *pspec)
 {
-	EvTransitionAnimationPriv *priv;
+	EvTransitionAnimationPrivate *priv;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (object);
+	priv = ev_transition_animation_get_instance_private (EV_TRANSITION_ANIMATION (object));
 
 	switch (prop_id) {
 	case PROP_EFFECT:
@@ -87,9 +86,9 @@ ev_transition_animation_get_property (GObject      *object,
 				      GValue       *value,
 				      GParamSpec   *pspec)
 {
-	EvTransitionAnimationPriv *priv;
+	EvTransitionAnimationPrivate *priv;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (object);
+	priv = ev_transition_animation_get_instance_private (EV_TRANSITION_ANIMATION (object));
 
 	switch (prop_id) {
 	case PROP_EFFECT:
@@ -109,9 +108,9 @@ ev_transition_animation_get_property (GObject      *object,
 static void
 ev_transition_animation_finalize (GObject *object)
 {
-	EvTransitionAnimationPriv *priv;
+	EvTransitionAnimationPrivate *priv;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (object);
+	priv = ev_transition_animation_get_instance_private (EV_TRANSITION_ANIMATION (object));
 
 	if (priv->effect)
 		g_object_unref (priv->effect);
@@ -130,16 +129,16 @@ ev_transition_animation_constructor (GType                  type,
 				     guint                  n_construct_properties,
 				     GObjectConstructParam *construct_params)
 {
-	GObject *object;
-	EvTransitionAnimationPriv *priv;
-	EvTransitionEffect *effect;
-	gint duration;
+	GObject                      *object;
+	EvTransitionAnimationPrivate *priv;
+	EvTransitionEffect           *effect;
+	gint                          duration;
 
 	object = G_OBJECT_CLASS (ev_transition_animation_parent_class)->constructor (type,
 										     n_construct_properties,
 										     construct_params);
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (object);
+	priv = ev_transition_animation_get_instance_private (EV_TRANSITION_ANIMATION (object));
 	effect = priv->effect;
 
 	g_object_get (effect, "duration", &duration, NULL);
@@ -177,8 +176,6 @@ ev_transition_animation_class_init (EvTransitionAnimationClass *klass)
 							       "Destination surface",
 							       "Cairo surface to which the animation will happen",
 							       G_PARAM_READWRITE));
-
-	g_type_class_add_private (klass, sizeof (EvTransitionAnimationPriv));
 }
 
 static void
@@ -212,12 +209,12 @@ ev_transition_animation_split (cairo_t               *cr,
 			       gdouble                progress,
 			       GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	EvTransitionEffectAlignment alignment;
-	EvTransitionEffectDirection direction;
-	gint width, height;
+	EvTransitionAnimationPrivate *priv;
+	EvTransitionEffectAlignment   alignment;
+	EvTransitionEffectDirection   direction;
+	gint                          width, height;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 	width = page_area.width;
 	height = page_area.height;
 
@@ -276,11 +273,11 @@ ev_transition_animation_blinds (cairo_t               *cr,
 				gdouble                progress,
 				GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	EvTransitionEffectAlignment alignment;
-	gint width, height, i;
+	EvTransitionAnimationPrivate *priv;
+	EvTransitionEffectAlignment   alignment;
+	gint                          width, height, i;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 	width = page_area.width;
 	height = page_area.height;
 
@@ -320,11 +317,11 @@ ev_transition_animation_box (cairo_t               *cr,
 			     gdouble                progress,
 			     GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	EvTransitionEffectDirection direction;
-	gint width, height;
+	EvTransitionAnimationPrivate *priv;
+	EvTransitionEffectDirection   direction;
+	gint                          width, height;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 	width = page_area.width;
 	height = page_area.height;
 
@@ -364,11 +361,11 @@ ev_transition_animation_wipe (cairo_t               *cr,
 			      gdouble                progress,
 			      GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	gint width, height;
-	gint angle;
+	EvTransitionAnimationPrivate *priv;
+	gint                          width, height;
+	gint                          angle;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 	width = page_area.width;
 	height = page_area.height;
 
@@ -418,9 +415,9 @@ ev_transition_animation_dissolve (cairo_t               *cr,
 				  gdouble                progress,
 				  GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
+	EvTransitionAnimationPrivate *priv;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 
 	paint_surface (cr, priv->dest_surface, 0, 0, 1., page_area);
 	paint_surface (cr, priv->origin_surface, 0, 0, 1 - progress, page_area);
@@ -433,11 +430,11 @@ ev_transition_animation_push (cairo_t               *cr,
 			      gdouble                progress,
 			      GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	gint width, height;
-	gint angle;
+	EvTransitionAnimationPrivate *priv;
+	gint                          width, height;
+	gint                          angle;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 	width = page_area.width;
 	height = page_area.height;
 
@@ -463,11 +460,11 @@ ev_transition_animation_cover (cairo_t               *cr,
 			       gdouble                progress,
 			       GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	gint width, height;
-	gint angle;
+	EvTransitionAnimationPrivate *priv;
+	gint                          width, height;
+	gint                          angle;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 	width = page_area.width;
 	height = page_area.height;
 
@@ -493,11 +490,11 @@ ev_transition_animation_uncover (cairo_t               *cr,
 				 gdouble                progress,
 				 GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	gint width, height;
-	gint angle;
+	EvTransitionAnimationPrivate *priv;
+	gint                          width, height;
+	gint                          angle;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 	width = page_area.width;
 	height = page_area.height;
 
@@ -523,9 +520,9 @@ ev_transition_animation_fade (cairo_t               *cr,
 			      gdouble                progress,
 			      GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
+	EvTransitionAnimationPrivate *priv;
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 
 	paint_surface (cr, priv->origin_surface, 0, 0, 1., page_area);
 	paint_surface (cr, priv->dest_surface, 0, 0, progress, page_area);
@@ -536,13 +533,13 @@ ev_transition_animation_paint (EvTransitionAnimation *animation,
 			       cairo_t               *cr,
 			       GdkRectangle           page_area)
 {
-	EvTransitionAnimationPriv *priv;
-	EvTransitionEffectType type;
-	gdouble progress;
+	EvTransitionAnimationPrivate *priv;
+	EvTransitionEffectType        type;
+	gdouble                       progress;
 
 	g_return_if_fail (EV_IS_TRANSITION_ANIMATION (animation));
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 
 	if (!priv->dest_surface) {
 		/* animation is still not ready, paint the origin surface */
@@ -615,12 +612,12 @@ void
 ev_transition_animation_set_origin_surface (EvTransitionAnimation *animation,
 					    cairo_surface_t       *origin_surface)
 {
-	EvTransitionAnimationPriv *priv;
+	EvTransitionAnimationPrivate *priv;
 	cairo_surface_t *surface;
 
 	g_return_if_fail (EV_IS_TRANSITION_ANIMATION (animation));
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 
 	if (priv->origin_surface == origin_surface)
 		return;
@@ -641,12 +638,12 @@ void
 ev_transition_animation_set_dest_surface (EvTransitionAnimation *animation,
 					  cairo_surface_t       *dest_surface)
 {
-	EvTransitionAnimationPriv *priv;
-	cairo_surface_t *surface;
+	EvTransitionAnimationPrivate *priv;
+	cairo_surface_t              *surface;
 
 	g_return_if_fail (EV_IS_TRANSITION_ANIMATION (animation));
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 
 	if (priv->dest_surface == dest_surface)
 		return;
@@ -666,11 +663,11 @@ ev_transition_animation_set_dest_surface (EvTransitionAnimation *animation,
 gboolean
 ev_transition_animation_ready (EvTransitionAnimation *animation)
 {
-	EvTransitionAnimationPriv *priv;
+	EvTransitionAnimationPrivate *priv;
 
 	g_return_val_if_fail (EV_IS_TRANSITION_ANIMATION (animation), FALSE);
 
-	priv = EV_TRANSITION_ANIMATION_GET_PRIVATE (animation);
+	priv = ev_transition_animation_get_instance_private (animation);
 
 	return (priv->origin_surface != NULL);
 }

--- a/libview/ev-view-accessible.c
+++ b/libview/ev-view-accessible.c
@@ -70,6 +70,7 @@ struct _EvViewAccessiblePrivate {
 };
 
 G_DEFINE_TYPE_WITH_CODE (EvViewAccessible, ev_view_accessible, GTK_TYPE_CONTAINER_ACCESSIBLE,
+			 G_ADD_PRIVATE (EvViewAccessible)
 			 G_IMPLEMENT_INTERFACE (ATK_TYPE_TEXT, ev_view_accessible_text_iface_init)
 			 G_IMPLEMENT_INTERFACE (ATK_TYPE_ACTION, ev_view_accessible_action_iface_init)
 			 G_IMPLEMENT_INTERFACE (ATK_TYPE_HYPERTEXT, ev_view_accessible_hypertext_iface_init)
@@ -114,14 +115,12 @@ ev_view_accessible_class_init (EvViewAccessibleClass *klass)
 
 	object_class->finalize = ev_view_accessible_finalize;
 	atk_class->initialize = ev_view_accessible_initialize;
-
-	g_type_class_add_private (klass, sizeof (EvViewAccessiblePrivate));
 }
 
 static void
 ev_view_accessible_init (EvViewAccessible *accessible)
 {
-	accessible->priv = G_TYPE_INSTANCE_GET_PRIVATE (accessible, EV_TYPE_VIEW_ACCESSIBLE, EvViewAccessiblePrivate);
+	accessible->priv = ev_view_accessible_get_instance_private (accessible);
 }
 
 static GtkTextBuffer *

--- a/shell/eggfindbar.c
+++ b/shell/eggfindbar.c
@@ -43,7 +43,6 @@ struct _EggFindBarPrivate
   guint case_sensitive : 1;
 };
 
-#define EGG_FIND_BAR_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EGG_TYPE_FIND_BAR, EggFindBarPrivate))
 
 enum {
     PROP_0,
@@ -64,7 +63,7 @@ static void egg_find_bar_show          (GtkWidget *widget);
 static void egg_find_bar_hide          (GtkWidget *widget);
 void egg_find_bar_grab_focus    (GtkWidget *widget);
 
-G_DEFINE_TYPE (EggFindBar, egg_find_bar, GTK_TYPE_TOOLBAR);
+G_DEFINE_TYPE_WITH_PRIVATE (EggFindBar, egg_find_bar, GTK_TYPE_TOOLBAR);
 
 enum
   {
@@ -162,7 +161,6 @@ egg_find_bar_class_init (EggFindBarClass *klass)
                                                          FALSE,
                                                          G_PARAM_READWRITE));
 
-  g_type_class_add_private (object_class, sizeof (EggFindBarPrivate));
 
   binding_set = gtk_binding_set_by_class (klass);
 
@@ -292,7 +290,7 @@ egg_find_bar_init (EggFindBar *find_bar)
   GtkWidget *arrow;
 
   /* Data */
-  priv = EGG_FIND_BAR_GET_PRIVATE (find_bar);
+  priv = egg_find_bar_get_instance_private (find_bar);
   
   find_bar->priv = priv;  
   priv->search_string = NULL;

--- a/shell/ev-file-monitor.c
+++ b/shell/ev-file-monitor.c
@@ -43,18 +43,16 @@ static void ev_file_monitor_changed_cb    (GFileMonitor     *monitor,
 					   GFile            *other_file,
 					   GFileMonitorEvent event_type,
 					   EvFileMonitor    *ev_monitor);
-	
-#define EV_FILE_MONITOR_GET_PRIVATE(object) \
-                (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_FILE_MONITOR, EvFileMonitorPrivate))
 
-G_DEFINE_TYPE (EvFileMonitor, ev_file_monitor, G_TYPE_OBJECT)
+
+G_DEFINE_TYPE_WITH_PRIVATE (EvFileMonitor, ev_file_monitor, G_TYPE_OBJECT)
 
 static guint signals[N_SIGNALS] = { 0 };
 
 static void
 ev_file_monitor_init (EvFileMonitor *ev_monitor)
 {
-	ev_monitor->priv = EV_FILE_MONITOR_GET_PRIVATE (ev_monitor);
+	ev_monitor->priv = ev_file_monitor_get_instance_private (ev_monitor);
 }
 
 static void
@@ -79,8 +77,6 @@ static void
 ev_file_monitor_class_init (EvFileMonitorClass *klass)
 {
 	GObjectClass *g_object_class = G_OBJECT_CLASS (klass);
-
-	g_type_class_add_private (g_object_class, sizeof (EvFileMonitorPrivate));
 
 	g_object_class->finalize = ev_file_monitor_finalize;
 

--- a/shell/ev-history-action-widget.c
+++ b/shell/ev-history-action-widget.c
@@ -34,7 +34,7 @@ typedef enum
     EV_HISTORY_ACTION_BUTTON_FORWARD
 } EvHistoryActionButton;
 
-G_DEFINE_TYPE (EvHistoryActionWidget, ev_history_action_widget, GTK_TYPE_TOOL_ITEM)
+G_DEFINE_TYPE_WITH_PRIVATE (EvHistoryActionWidget, ev_history_action_widget, GTK_TYPE_TOOL_ITEM)
 
 static void
 ev_history_action_widget_finalize (GObject *object)
@@ -235,7 +235,7 @@ ev_history_action_widget_init (EvHistoryActionWidget *history_widget)
     EvHistoryActionWidgetPrivate *priv;
     GtkWidget *box;
 
-    history_widget->priv = G_TYPE_INSTANCE_GET_PRIVATE (history_widget, EV_TYPE_HISTORY_ACTION_WIDGET, EvHistoryActionWidgetPrivate);
+    history_widget->priv = ev_history_action_widget_get_instance_private (history_widget);
     priv = history_widget->priv;
 
     box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
@@ -272,7 +272,6 @@ ev_history_action_widget_class_init (EvHistoryActionWidgetClass *klass)
                                                            G_PARAM_READABLE |
                                                            G_PARAM_STATIC_STRINGS));
 
-    g_type_class_add_private (object_class, sizeof (EvHistoryActionWidgetPrivate));
 }
 
 static void

--- a/shell/ev-history-action.c
+++ b/shell/ev-history-action.c
@@ -22,7 +22,7 @@ struct _EvHistoryActionPrivate
     gboolean popup_shown;
 };
 
-G_DEFINE_TYPE (EvHistoryAction, ev_history_action, GTK_TYPE_ACTION)
+G_DEFINE_TYPE_WITH_PRIVATE (EvHistoryAction, ev_history_action, GTK_TYPE_ACTION)
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
@@ -68,13 +68,12 @@ ev_history_action_class_init (EvHistoryActionClass *class)
                           g_cclosure_marshal_VOID__VOID,
                           G_TYPE_NONE, 0);
 
-    g_type_class_add_private (object_class, sizeof (EvHistoryActionPrivate));
 }
 
 static void
 ev_history_action_init (EvHistoryAction *action)
 {
-    action->priv = G_TYPE_INSTANCE_GET_PRIVATE (action, EV_TYPE_HISTORY_ACTION, EvHistoryActionPrivate);
+    action->priv = ev_history_action_get_instance_private (action);
 }
 
 void

--- a/shell/ev-history.c
+++ b/shell/ev-history.c
@@ -48,7 +48,7 @@ struct _EvHistoryPrivate
 	guint frozen;
 };
 
-G_DEFINE_TYPE (EvHistory, ev_history, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE(EvHistory, ev_history, G_TYPE_OBJECT)
 
 static void ev_history_set_model (EvHistory       *history,
 								  EvDocumentModel *model);
@@ -133,13 +133,12 @@ ev_history_class_init (EvHistoryClass *class)
 				              G_TYPE_NONE, 1,
 				              G_TYPE_OBJECT);
 
-	g_type_class_add_private (object_class, sizeof (EvHistoryPrivate));
 }
 
 static void
 ev_history_init (EvHistory *history)
 {
-	history->priv = G_TYPE_INSTANCE_GET_PRIVATE (history, EV_TYPE_HISTORY, EvHistoryPrivate);
+	history->priv = ev_history_get_instance_private (history);
 }
 
 static gboolean

--- a/shell/ev-message-area.c
+++ b/shell/ev-message-area.c
@@ -25,9 +25,6 @@
 
 #include "ev-message-area.h"
 
-#define EV_MESSAGE_AREA_GET_PRIVATE(obj) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((obj), EV_TYPE_MESSAGE_AREA, EvMessageAreaPrivate))
-
 struct _EvMessageAreaPrivate {
 	GtkWidget *main_box;
 	GtkWidget *image;
@@ -53,7 +50,7 @@ static void ev_message_area_get_property (GObject      *object,
 					  GValue       *value,
 					  GParamSpec   *pspec);
 
-G_DEFINE_TYPE (EvMessageArea, ev_message_area, GTK_TYPE_INFO_BAR)
+G_DEFINE_TYPE_WITH_PRIVATE (EvMessageArea, ev_message_area, GTK_TYPE_INFO_BAR)
 
 static void
 ev_message_area_class_init (EvMessageAreaClass *class)
@@ -84,8 +81,6 @@ ev_message_area_class_init (EvMessageAreaClass *class)
 							      "The image",
 							      GTK_TYPE_WIDGET,
 							      G_PARAM_READWRITE));
-
-	g_type_class_add_private (gobject_class, sizeof (EvMessageAreaPrivate));
 }
 
 static void
@@ -94,7 +89,7 @@ ev_message_area_init (EvMessageArea *area)
 	GtkWidget *hbox, *vbox;
 	GtkWidget *content_area;
 
-	area->priv = EV_MESSAGE_AREA_GET_PRIVATE (area);
+	area->priv = ev_message_area_get_instance_private (area);
 
 	area->priv->main_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
 

--- a/shell/ev-password-view.c
+++ b/shell/ev-password-view.c
@@ -45,13 +45,10 @@ struct _EvPasswordViewPrivate {
 	GFile        *uri_file;
 };
 
-#define EV_PASSWORD_VIEW_GET_PRIVATE(object) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_PASSWORD_VIEW, EvPasswordViewPrivate));
-
 static guint password_view_signals [LAST_SIGNAL] = { 0 };
 
 
-G_DEFINE_TYPE (EvPasswordView, ev_password_view, GTK_TYPE_VIEWPORT)
+G_DEFINE_TYPE_WITH_PRIVATE (EvPasswordView, ev_password_view, GTK_TYPE_VIEWPORT)
 
 static void
 ev_password_view_finalize (GObject *object)
@@ -89,8 +86,6 @@ ev_password_view_class_init (EvPasswordViewClass *class)
 			      g_cclosure_marshal_VOID__VOID,
 			      G_TYPE_NONE, 0);
 
-	g_type_class_add_private (g_object_class, sizeof (EvPasswordViewPrivate));
-
 	g_object_class->finalize = ev_password_view_finalize;
 }
 
@@ -111,7 +106,7 @@ ev_password_view_init (EvPasswordView *password_view)
 	GtkWidget *label;
 	gchar     *markup;
 
-	password_view->priv = EV_PASSWORD_VIEW_GET_PRIVATE (password_view);
+	password_view->priv = ev_password_view_get_instance_private (password_view);
 
 	password_view->priv->password_save = G_PASSWORD_SAVE_NEVER;
 

--- a/shell/ev-progress-message-area.c
+++ b/shell/ev-progress-message-area.c
@@ -24,9 +24,6 @@
 
 #include "ev-progress-message-area.h"
 
-#define EV_PROGRESS_MESSAGE_AREA_GET_PRIVATE(obj) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((obj), EV_TYPE_PROGRESS_MESSAGE_AREA, EvProgressMessageAreaPrivate))
-
 struct _EvProgressMessageAreaPrivate {
 	GtkWidget *label;
 	GtkWidget *progress_bar;
@@ -47,7 +44,7 @@ static void ev_progress_message_area_get_property (GObject      *object,
 						   GValue       *value,
 						   GParamSpec   *pspec);
 
-G_DEFINE_TYPE (EvProgressMessageArea, ev_progress_message_area, EV_TYPE_MESSAGE_AREA)
+G_DEFINE_TYPE_WITH_PRIVATE (EvProgressMessageArea, ev_progress_message_area, EV_TYPE_MESSAGE_AREA)
 
 static void
 ev_progress_message_area_class_init (EvProgressMessageAreaClass *class)
@@ -71,8 +68,6 @@ ev_progress_message_area_class_init (EvProgressMessageAreaClass *class)
 							      "The fraction of total work that has been completed",
 							      0.0, 1.0, 0.0,
 							      G_PARAM_READWRITE));
-
-	g_type_class_add_private (gobject_class, sizeof (EvProgressMessageAreaPrivate));
 }
 
 static void
@@ -81,7 +76,7 @@ ev_progress_message_area_init (EvProgressMessageArea *area)
 	GtkWidget *contents;
 	GtkWidget *vbox;
 
-	area->priv = EV_PROGRESS_MESSAGE_AREA_GET_PRIVATE (area);
+	area->priv = ev_progress_message_area_get_instance_private (area);
 
 	contents = _ev_message_area_get_main_box (EV_MESSAGE_AREA (area));
 

--- a/shell/ev-recent-view.c
+++ b/shell/ev-recent-view.c
@@ -50,7 +50,7 @@ enum {
 
 static guint signals[NUM_SIGNALS] = { 0, };
 
-G_DEFINE_TYPE (EvRecentView, ev_recent_view, GTK_TYPE_SCROLLED_WINDOW)
+G_DEFINE_TYPE_WITH_PRIVATE (EvRecentView, ev_recent_view, GTK_TYPE_SCROLLED_WINDOW)
 
 #define THUMBNAIL_WIDTH 80
 
@@ -209,7 +209,7 @@ ev_recent_view_refresh (EvRecentView *ev_recent_view)
 static void
 ev_recent_view_init (EvRecentView *ev_recent_view)
 {
-    ev_recent_view->priv = G_TYPE_INSTANCE_GET_PRIVATE (ev_recent_view, EV_TYPE_RECENT_VIEW, EvRecentViewPrivate);
+    ev_recent_view->priv = ev_recent_view_get_instance_private (ev_recent_view);
 
     gtk_widget_set_hexpand (GTK_WIDGET (ev_recent_view), TRUE);
     gtk_widget_set_vexpand (GTK_WIDGET (ev_recent_view), TRUE);
@@ -313,8 +313,6 @@ ev_recent_view_class_init (EvRecentViewClass *klass)
                           g_cclosure_marshal_generic,
                           G_TYPE_NONE, 1,
                           G_TYPE_STRING);
-
-    g_type_class_add_private (klass, sizeof (EvRecentViewPrivate));
 }
 
 

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -66,11 +66,9 @@ G_DEFINE_TYPE_EXTENDED (EvSidebarAnnotations,
                         ev_sidebar_annotations,
                         GTK_TYPE_BOX,
                         0,
+                        G_ADD_PRIVATE (EvSidebarAnnotations)
                         G_IMPLEMENT_INTERFACE (EV_TYPE_SIDEBAR_PAGE,
 					       ev_sidebar_annotations_page_iface_init))
-
-#define EV_SIDEBAR_ANNOTATIONS_GET_PRIVATE(object) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_SIDEBAR_ANNOTATIONS, EvSidebarAnnotationsPrivate))
 
 static void
 ev_sidebar_annotations_dispose (GObject *object)
@@ -124,7 +122,7 @@ ev_sidebar_annotations_init (EvSidebarAnnotations *ev_annots)
 	GtkWidget *toolitem;
 	GtkWidget *hbox;
 
-	ev_annots->priv = EV_SIDEBAR_ANNOTATIONS_GET_PRIVATE (ev_annots);
+	ev_annots->priv = ev_sidebar_annotations_get_instance_private (ev_annots);
 
 	gtk_orientable_set_orientation (GTK_ORIENTABLE (ev_annots), GTK_ORIENTATION_VERTICAL);
 
@@ -210,8 +208,6 @@ ev_sidebar_annotations_class_init (EvSidebarAnnotationsClass *klass)
 	g_object_class->get_property = ev_sidebar_annotations_get_property;
 	g_object_class->dispose = ev_sidebar_annotations_dispose;
 
-	g_type_class_add_private (g_object_class, sizeof (EvSidebarAnnotationsPrivate));
-
 	g_object_class_override_property (g_object_class, PROP_WIDGET, "main-widget");
 
 	signals[ANNOT_ACTIVATED] =
@@ -248,7 +244,7 @@ ev_sidebar_annotations_annot_removed (EvSidebarAnnotations *sidebar_annots,
 EvAnnotationsToolbar *
 ev_sidebar_annotations_get_toolbar(EvSidebarAnnotations *sidebar_annots)
 {
-	EvSidebarAnnotationsPrivate *priv = EV_SIDEBAR_ANNOTATIONS_GET_PRIVATE(sidebar_annots);
+	EvSidebarAnnotationsPrivate *priv = ev_sidebar_annotations_get_instance_private(sidebar_annots);
 	return EV_ANNOTATIONS_TOOLBAR(priv->toolbar);
 }
 

--- a/shell/ev-sidebar-attachments.c
+++ b/shell/ev-sidebar-attachments.c
@@ -74,11 +74,9 @@ G_DEFINE_TYPE_EXTENDED (EvSidebarAttachments,
                         ev_sidebar_attachments,
                         GTK_TYPE_BOX,
                         0, 
+                        G_ADD_PRIVATE (EvSidebarAttachments)
                         G_IMPLEMENT_INTERFACE (EV_TYPE_SIDEBAR_PAGE, 
 					       ev_sidebar_attachments_page_iface_init))
-
-#define EV_SIDEBAR_ATTACHMENTS_GET_PRIVATE(object) \
-                (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_SIDEBAR_ATTACHMENTS, EvSidebarAttachmentsPrivate))
 
 /* Icon cache */
 static void
@@ -512,8 +510,6 @@ ev_sidebar_attachments_class_init (EvSidebarAttachmentsClass *ev_attachbar_class
 	gtk_widget_class->popup_menu = ev_sidebar_attachments_popup_menu;
 	gtk_widget_class->screen_changed = ev_sidebar_attachments_screen_changed;
 
-	g_type_class_add_private (g_object_class, sizeof (EvSidebarAttachmentsPrivate));
-
 	/* Signals */
 	signals[SIGNAL_POPUP_MENU] =
 		g_signal_new ("popup",
@@ -535,7 +531,7 @@ ev_sidebar_attachments_init (EvSidebarAttachments *ev_attachbar)
 {
 	GtkWidget *swindow;
 	
-	ev_attachbar->priv = EV_SIDEBAR_ATTACHMENTS_GET_PRIVATE (ev_attachbar);
+	ev_attachbar->priv = ev_sidebar_attachments_get_instance_private (ev_attachbar);
 
 	gtk_orientable_set_orientation (GTK_ORIENTABLE (ev_attachbar), GTK_ORIENTATION_VERTICAL);
 	swindow = gtk_scrolled_window_new (NULL, NULL);

--- a/shell/ev-sidebar-bookmarks.c
+++ b/shell/ev-sidebar-bookmarks.c
@@ -66,6 +66,7 @@ G_DEFINE_TYPE_EXTENDED (EvSidebarBookmarks,
                         ev_sidebar_bookmarks,
                         GTK_TYPE_BOX,
                         0,
+                        G_ADD_PRIVATE (EvSidebarBookmarks)
                         G_IMPLEMENT_INTERFACE (EV_TYPE_SIDEBAR_PAGE,
                                                ev_sidebar_bookmarks_page_iface_init))
 
@@ -426,9 +427,7 @@ ev_sidebar_bookmarks_init (EvSidebarBookmarks *sidebar_bookmarks)
         GtkCellRenderer *renderer;
         GtkTreeSelection *selection;
 
-        sidebar_bookmarks->priv = G_TYPE_INSTANCE_GET_PRIVATE (sidebar_bookmarks,
-                                                               EV_TYPE_SIDEBAR_BOOKMARKS,
-                                                               EvSidebarBookmarksPrivate);
+        sidebar_bookmarks->priv = ev_sidebar_bookmarks_get_instance_private (sidebar_bookmarks);
         priv = sidebar_bookmarks->priv;
 
         gtk_orientable_set_orientation (GTK_ORIENTABLE (sidebar_bookmarks), GTK_ORIENTATION_VERTICAL);
@@ -545,8 +544,6 @@ ev_sidebar_bookmarks_class_init (EvSidebarBookmarksClass *klass)
         g_object_class->dispose = ev_sidebar_bookmarks_dispose;
 
         widget_class->popup_menu = ev_sidebar_bookmarks_popup_menu;
-
-        g_type_class_add_private (g_object_class, sizeof (EvSidebarBookmarksPrivate));
 
         g_object_class_override_property (g_object_class, PROP_WIDGET, "main-widget");
 

--- a/shell/ev-sidebar-layers.c
+++ b/shell/ev-sidebar-layers.c
@@ -56,11 +56,9 @@ G_DEFINE_TYPE_EXTENDED (EvSidebarLayers,
                         ev_sidebar_layers,
                         GTK_TYPE_BOX,
                         0, 
+                        G_ADD_PRIVATE (EvSidebarLayers)
                         G_IMPLEMENT_INTERFACE (EV_TYPE_SIDEBAR_PAGE, 
 					       ev_sidebar_layers_page_iface_init))
-
-#define EV_SIDEBAR_LAYERS_GET_PRIVATE(object) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_SIDEBAR_LAYERS, EvSidebarLayersPrivate))
 
 static void
 ev_sidebar_layers_dispose (GObject *object)
@@ -279,7 +277,7 @@ ev_sidebar_layers_init (EvSidebarLayers *ev_layers)
 	GtkWidget    *swindow;
 	GtkTreeModel *model;
 	
-	ev_layers->priv = EV_SIDEBAR_LAYERS_GET_PRIVATE (ev_layers);
+	ev_layers->priv = ev_sidebar_layers_get_instance_private (ev_layers);
 
 	swindow = gtk_scrolled_window_new (NULL, NULL);
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (swindow),
@@ -308,8 +306,6 @@ ev_sidebar_layers_class_init (EvSidebarLayersClass *ev_layers_class)
 
 	g_object_class->get_property = ev_sidebar_layers_get_property;
 	g_object_class->dispose = ev_sidebar_layers_dispose;
-
-	g_type_class_add_private (g_object_class, sizeof (EvSidebarLayersPrivate));
 
 	g_object_class_override_property (g_object_class, PROP_WIDGET, "main-widget");
 

--- a/shell/ev-sidebar-links.c
+++ b/shell/ev-sidebar-links.c
@@ -84,12 +84,10 @@ G_DEFINE_TYPE_EXTENDED (EvSidebarLinks,
                         ev_sidebar_links,
                         GTK_TYPE_BOX,
                         0,
+                        G_ADD_PRIVATE (EvSidebarLinks)
                         G_IMPLEMENT_INTERFACE (EV_TYPE_SIDEBAR_PAGE,
 					       ev_sidebar_links_page_iface_init))
 
-
-#define EV_SIDEBAR_LINKS_GET_PRIVATE(object) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_SIDEBAR_LINKS, EvSidebarLinksPrivate))
 
 static void
 ev_sidebar_links_set_property (GObject      *object,
@@ -209,8 +207,6 @@ ev_sidebar_links_class_init (EvSidebarLinksClass *ev_sidebar_links_class)
 	g_object_class_override_property (g_object_class,
 					  PROP_WIDGET,
 					  "main-widget");
-
-	g_type_class_add_private (g_object_class, sizeof (EvSidebarLinksPrivate));
 }
 
 static void
@@ -450,7 +446,7 @@ ev_sidebar_links_construct (EvSidebarLinks *ev_sidebar_links)
 static void
 ev_sidebar_links_init (EvSidebarLinks *ev_sidebar_links)
 {
-	ev_sidebar_links->priv = EV_SIDEBAR_LINKS_GET_PRIVATE (ev_sidebar_links);
+	ev_sidebar_links->priv = ev_sidebar_links_get_instance_private (ev_sidebar_links);
 
 	gtk_orientable_set_orientation (GTK_ORIENTABLE (ev_sidebar_links), GTK_ORIENTATION_VERTICAL);
 

--- a/shell/ev-sidebar-thumbnails.c
+++ b/shell/ev-sidebar-thumbnails.c
@@ -118,11 +118,9 @@ G_DEFINE_TYPE_EXTENDED (EvSidebarThumbnails,
                         ev_sidebar_thumbnails,
                         GTK_TYPE_BOX,
                         0,
+                        G_ADD_PRIVATE (EvSidebarThumbnails)
                         G_IMPLEMENT_INTERFACE (EV_TYPE_SIDEBAR_PAGE,
 					       ev_sidebar_thumbnails_page_iface_init))
-
-#define EV_SIDEBAR_THUMBNAILS_GET_PRIVATE(object) \
-	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_SIDEBAR_THUMBNAILS, EvSidebarThumbnailsPrivate));
 
 /* Thumbnails dimensions cache */
 #define EV_THUMBNAILS_SIZE_CACHE_KEY "ev-thumbnails-size-cache"
@@ -445,7 +443,6 @@ ev_sidebar_thumbnails_class_init (EvSidebarThumbnailsClass *ev_sidebar_thumbnail
 					  PROP_WIDGET,
 					  "main-widget");
 
-	g_type_class_add_private (g_object_class, sizeof (EvSidebarThumbnailsPrivate));
 
 	signals[SIZE_CHANGED] =
 		g_signal_new ("size-changed",
@@ -900,7 +897,7 @@ ev_sidebar_thumbnails_init (EvSidebarThumbnails *ev_sidebar_thumbnails)
 	GtkWidget *hbox;
 	GtkWidget *image;
 
-	priv = ev_sidebar_thumbnails->priv = EV_SIDEBAR_THUMBNAILS_GET_PRIVATE (ev_sidebar_thumbnails);
+	priv = ev_sidebar_thumbnails->priv = ev_sidebar_thumbnails_get_instance_private (ev_sidebar_thumbnails);
 
 	gtk_orientable_set_orientation (GTK_ORIENTABLE (ev_sidebar_thumbnails), GTK_ORIENTATION_VERTICAL);
 

--- a/shell/ev-sidebar.c
+++ b/shell/ev-sidebar.c
@@ -58,10 +58,7 @@ struct _EvSidebarPrivate {
 	GtkTreeModel *page_model;
 };
 
-G_DEFINE_TYPE (EvSidebar, ev_sidebar, GTK_TYPE_BOX)
-
-#define EV_SIDEBAR_GET_PRIVATE(object) \
-		(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_SIDEBAR, EvSidebarPrivate))
+G_DEFINE_TYPE_WITH_PRIVATE (EvSidebar, ev_sidebar, GTK_TYPE_BOX)
 
 static void
 ev_sidebar_dispose (GObject *object)
@@ -177,7 +174,6 @@ ev_sidebar_class_init (EvSidebarClass *ev_sidebar_class)
 	GObjectClass *g_object_class;
 
 	g_object_class = G_OBJECT_CLASS (ev_sidebar_class);
-	g_type_class_add_private (g_object_class, sizeof (EvSidebarPrivate));
 
 	g_object_class->dispose = ev_sidebar_dispose;
 	g_object_class->get_property = ev_sidebar_get_property;
@@ -336,7 +332,7 @@ ev_sidebar_init (EvSidebar *ev_sidebar)
 	GtkWidget *select_hbox;
 	GtkWidget *arrow;
 
-	ev_sidebar->priv = EV_SIDEBAR_GET_PRIVATE (ev_sidebar);
+	ev_sidebar->priv = ev_sidebar_get_instance_private (ev_sidebar);
 
 	gtk_orientable_set_orientation (GTK_ORIENTABLE (ev_sidebar), GTK_ORIENTATION_VERTICAL);
 

--- a/shell/ev-toolbar.c
+++ b/shell/ev-toolbar.c
@@ -34,7 +34,7 @@ struct _EvToolbarPrivate
     EvDocumentModel *model;
 };
 
-G_DEFINE_TYPE (EvToolbar, ev_toolbar, GTK_TYPE_TOOLBAR)
+G_DEFINE_TYPE_WITH_PRIVATE (EvToolbar, ev_toolbar, GTK_TYPE_TOOLBAR)
 
 static void
 ev_toolbar_set_property (GObject      *object,
@@ -353,14 +353,12 @@ ev_toolbar_class_init (EvToolbarClass *klass)
                                                           G_PARAM_WRITABLE |
                                                           G_PARAM_CONSTRUCT_ONLY |
                                                           G_PARAM_STATIC_STRINGS));
-
-    g_type_class_add_private (object_class, sizeof (EvToolbarPrivate));
 }
 
 static void
 ev_toolbar_init (EvToolbar *ev_toolbar)
 {
-    ev_toolbar->priv = G_TYPE_INSTANCE_GET_PRIVATE (ev_toolbar, EV_TYPE_TOOLBAR, EvToolbarPrivate);
+    ev_toolbar->priv = ev_toolbar_get_instance_private (ev_toolbar);
     ev_toolbar->priv->settings = g_settings_new (GS_SCHEMA_NAME_TOOLBAR);
 }
 

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -228,9 +228,6 @@ struct _EvWindowPrivate {
 #endif
 };
 
-#define EV_WINDOW_GET_PRIVATE(object) \
-        (G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_WINDOW, EvWindowPrivate))
-
 #define EV_WINDOW_IS_PRESENTATION(w) (w->priv->presentation_view != NULL)
 
 #define PAGE_SELECTOR_ACTION            "PageSelector"
@@ -359,7 +356,7 @@ static void    recent_view_item_activated_cb                 (EvRecentView   *re
                                                               const char       *uri,
                                                               EvWindow         *ev_window);
 
-G_DEFINE_TYPE (EvWindow, ev_window, GTK_TYPE_APPLICATION_WINDOW)
+G_DEFINE_TYPE_WITH_PRIVATE (EvWindow, ev_window, GTK_TYPE_APPLICATION_WINDOW)
 
 static gdouble
 get_screen_dpi (EvWindow *window)
@@ -4436,7 +4433,7 @@ ev_window_cmd_view_zoom (GSimpleAction *action,
 			 gpointer       user_data)
 {
     EvWindow *ev_window = user_data;
-    EvWindowPrivate *priv = EV_WINDOW_GET_PRIVATE (ev_window);
+    EvWindowPrivate *priv = ev_window_get_instance_private (ev_window);
     gdouble zoom = g_variant_get_double (parameter);
 
     ev_document_model_set_sizing_mode (priv->model, EV_SIZING_FREE);
@@ -5850,8 +5847,6 @@ ev_window_class_init (EvWindowClass *ev_window_class)
     widget_class->screen_changed = ev_window_screen_changed;
     widget_class->window_state_event = ev_window_state_event;
     widget_class->drag_data_received = ev_window_drag_data_received;
-
-    g_type_class_add_private (g_object_class, sizeof (EvWindowPrivate));
 }
 
 /* Normal items */
@@ -7324,7 +7319,7 @@ ev_window_init (EvWindow *ev_window)
     g_signal_connect (ev_window, "window_state_event",
             G_CALLBACK (window_state_event_cb), NULL);
 
-    ev_window->priv = EV_WINDOW_GET_PRIVATE (ev_window);
+    ev_window->priv = ev_window_get_instance_private (ev_window);
 
 #ifdef ENABLE_DBUS
     connection = g_application_get_dbus_connection (g_application_get_default ());


### PR DESCRIPTION
 The g_type_class_add_private function and G_TYPE_INSTANCE_GET_PRIVATE
 macro are deprecated. Replace with the G_DEFINE_TYPE_PRIVATE and
 G_ADD_PRIVATE macros, and *_get_instance_private functions.

Based on https://github.com/GNOME/evince/commit/e73364886a3261e89cbb43cf149fb412d30c3c1c