### PR TITLE
Some improvements and fixes to the test suite

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,9 +17,6 @@ override_dh_install:
 	sed 's@TYPELIBDIR@${TYPELIBDIR}@' debian/gir1.2-xreader.install.in > debian/gir1.2-xreader.install
 	dh_install --fail-missing
 
-override_dh_auto_test:
-	ninja -C debian/build test
-
 override_dh_auto_configure:
 	meson debian/build \
 		--prefix=/usr \
@@ -33,7 +30,6 @@ override_dh_auto_configure:
 		-D comics=true \
 		-D introspection=true \
 		-D help_files=true \
-		-D tests=false
 	# 	--disable-static \
 
 override_dh_strip:

--- a/meson.build
+++ b/meson.build
@@ -185,9 +185,13 @@ subdir('shell')
 subdir('po')
 subdir('help')
 subdir('install-scripts')
-# tests are currently outdated and will not work with current xreader.
-# to reenable tests, change "false" to "get_option('tests')"
-if get_option('tests')
+
+# The tests use an option that doesn't exist in meson before 0.46.
+# Since they aren't strictly necessary, we'll just skip them for earlier versions
+# rather than making 0.46 a hard requirement. This condition can be removed once we
+# no longer need to worry about building on 0.45 or earlier
+meson_version_parts = meson.version().split('.')
+if meson_version_parts[0].to_int() > 0 or meson_version_parts[1].to_int() >= 46
     subdir('test')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -73,11 +73,6 @@ option('thumbnailer',
     value: true,
     description: 'Build the thumbnailer program'
 )
-option('tests',
-    type: 'boolean',
-    value: true,
-    description: ''
-)
 option('docs',
     type: 'boolean',
     value: false,

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -143,7 +143,7 @@ libshell = static_library(
     include_directories: [include_dirs, cnc_includes],
 )
 
-executable(
+xreader = executable(
     'xreader',
     'main.c',
     link_with: libview,

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,11 @@
-test_cases = ['testFileMenu.py', 'testEditMenu.py', 'testHelpMenu.py',
-		'testZoom.py', 'testGoMenu.py', 'testBookmarksMenu.py']
+test_cases = [
+    'testFileMenu.py',
+    'testEditMenu.py',
+    'testHelpMenu.py',
+    'testZoom.py',
+    'testGoMenu.py',
+    'testBookmarksMenu.py'
+]
 
 foreach case : test_cases
     test_script = find_program(case)
@@ -7,6 +13,7 @@ foreach case : test_cases
     test(
         case,
         test_script,
+        args: [xreader.full_path()],
         is_parallel: false,
         depends: xreader,
         workdir: join_paths(prefix, bindir),

--- a/test/meson.build
+++ b/test/meson.build
@@ -8,7 +8,7 @@ foreach case : test_cases
         case,
         test_script,
         is_parallel: false,
-        depends: 'xreader',
+        depends: xreader,
         workdir: join_paths(prefix, bindir),
     )
 endforeach

--- a/test/meson.build
+++ b/test/meson.build
@@ -17,5 +17,6 @@ foreach case : test_cases
         is_parallel: false,
         depends: xreader,
         workdir: join_paths(prefix, bindir),
+        timeout: 120,
     )
 endforeach

--- a/test/testBookmarksMenu.py
+++ b/test/testBookmarksMenu.py
@@ -2,30 +2,29 @@
 
 # This test opens the Bookmarks menu.
 
-import os
-os.environ['LANG']='C'
+from testCommon import run_app, bail
 
 from dogtail.procedural import *
 
-import dogtail.config
-dogtail.config.config.logDebugToStdOut = True
-dogtail.config.config.logDebugToFile = False
+try:
+    run_app()
 
-run('xreader')
+    # Open a file
+    click('File', roleName='menu')
+    click('Open…', roleName='menu item')
+    click('test-links.pdf', roleName='table cell')
+    click('Open', roleName='push button')
 
-# Open a file
-click('File', roleName='menu')
-click('Open…', roleName='menu item')
-click('test-links.pdf', roleName='table cell')
-click('Open', roleName='push button')
+    focus.frame('test-links.pdf')
+    click('Bookmarks', roleName='menu')
+    click('Add Bookmark', roleName='menu item')
 
-focus.frame('test-links.pdf')
-click('Bookmarks', roleName='menu')
-click('Add Bookmark', roleName='menu item')
+    click('Bookmarks', roleName='menu')
+    click('Page 1', roleName='menu item')
 
-click('Bookmarks', roleName='menu')
-click('Page 1', roleName='menu item')
+    # Close
+    click('File', roleName='menu')
+    click('Close', roleName='menu item')
 
-# Close
-click('File', roleName='menu')
-click('Close', roleName='menu item')
+except:
+    bail()

--- a/test/testBookmarksMenu.py
+++ b/test/testBookmarksMenu.py
@@ -7,13 +7,7 @@ from testCommon import run_app, bail
 from dogtail.procedural import *
 
 try:
-    run_app()
-
-    # Open a file
-    click('File', roleName='menu')
-    click('Open…', roleName='menu item')
-    click('test-links.pdf', roleName='table cell')
-    click('Open', roleName='push button')
+    run_app(file='test-links.pdf')
 
     focus.frame('test-links.pdf')
     click('Bookmarks', roleName='menu')

--- a/test/testCommon.py
+++ b/test/testCommon.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import signal
+
+os.environ['LANG'] = 'C'
+
+from dogtail.config import config
+config.logDebugToStdOut = True
+config.logDebugToFile = False
+
+import dogtail.procedural as dt
+
+def run_app(file=None):
+    global pid
+
+    if file is not None:
+        arguments = os.path.join(os.path.dirname(__file__), file)
+    else:
+        arguments = ''
+    pid = dt.run(sys.argv[1], arguments=arguments, appName='xreader')
+
+def bail():
+    os.kill(pid, signal.SIGTERM)
+    sys.exit(1)

--- a/test/testEditMenu.py
+++ b/test/testEditMenu.py
@@ -7,13 +7,7 @@ from testCommon import run_app, bail
 from dogtail.procedural import *
 
 try:
-    run_app()
-
-    # Open a file
-    click('File', roleName='menu')
-    click('Open…', roleName='menu item')
-    click('test-links.pdf', roleName='table cell')
-    click('Open', roleName='push button')
+    run_app(file='test-links.pdf')
 
     # Begin to run through Edit options
     focus.frame('test-links.pdf')

--- a/test/testEditMenu.py
+++ b/test/testEditMenu.py
@@ -2,57 +2,56 @@
 
 # This test opens the Edit menu and runs through the menu items.
 
-import os
-os.environ['LANG']='C'
+from testCommon import run_app, bail
 
 from dogtail.procedural import *
 
-import dogtail.config
-dogtail.config.config.logDebugToStdOut = True
-dogtail.config.config.logDebugToFile = False
+try:
+    run_app()
 
-run('xreader')
+    # Open a file
+    click('File', roleName='menu')
+    click('Open…', roleName='menu item')
+    click('test-links.pdf', roleName='table cell')
+    click('Open', roleName='push button')
 
-# Open a file
-click('File', roleName='menu')
-click('Open…', roleName='menu item')
-click('test-links.pdf', roleName='table cell')
-click('Open', roleName='push button')
+    # Begin to run through Edit options
+    focus.frame('test-links.pdf')
+    click('Edit', roleName='menu')
 
-# Begin to run through Edit options
-focus.frame('test-links.pdf')
-click('Edit', roleName='menu')
+    click('Select All', roleName='menu item')
 
-click('Select All', roleName='menu item')
+    click('Edit', roleName='menu')
+    click('Find…', roleName='menu item')
 
-click('Edit', roleName='menu')
-click('Find…', roleName='menu item')
+    focus.frame('test-links.pdf')
+    type('link')
+    click('Find Previous', roleName='push button')
 
-focus.frame('test-links.pdf')
-type('link')
-click('Find Previous', roleName='push button')
+    click('Edit', roleName='menu')
+    click('Find Next', roleName='menu item')
 
-click('Edit', roleName='menu')
-click('Find Next', roleName='menu item')
+    click('Edit', roleName='menu')
+    click('Find Previous', roleName='menu item')
 
-click('Edit', roleName='menu')
-click('Find Previous', roleName='menu item')
+    click('Edit', roleName='menu')
+    click('Rotate Left', roleName='menu item')
 
-click('Edit', roleName='menu')
-click('Rotate Left', roleName='menu item')
+    click('Edit', roleName='menu')
+    click('Rotate Right', roleName='menu item')
 
-click('Edit', roleName='menu')
-click('Rotate Right', roleName='menu item')
+    click('Edit', roleName='menu')
+    click('Save Current Settings as Default', roleName='menu item')
 
-click('Edit', roleName='menu')
-click('Save Current Settings as Default', roleName='menu item')
+    click('Edit', roleName='menu')
+    click('Preferences', roleName='menu item')
 
-click('Edit', roleName='menu')
-click('Preferences', roleName='menu item')
+    focus.frame('Preferences')
+    click('Close', roleName='push button')
 
-focus.frame('Preferences')
-click('Close', roleName='push button')
+    focus.frame('test-links.pdf')
+    click('File', roleName='menu')
+    click('Close', roleName='menu item')
 
-focus.frame('test-links.pdf')
-click('File', roleName='menu')
-click('Close', roleName='menu item')
+except:
+    bail()

--- a/test/testFileMenu.py
+++ b/test/testFileMenu.py
@@ -2,45 +2,45 @@
 
 # Test that the File menu and menu items work correctly.
 
-import os
-os.environ['LANG']='C'
+from testCommon import run_app, bail
 
 from dogtail.procedural import *
-import dogtail.config
-dogtail.config.config.logDebugToStdOut = True
-dogtail.config.config.logDebugToFile = False
 
-run('xreader')
+try:
+    run_app()
 
-# Open a file
-click('File', roleName='menu')
-click('Open…', roleName='menu item')
-click('test-links.pdf', roleName='table cell')
-click('Open', roleName='push button')
+    # Open a file
+    click('File', roleName='menu')
+    click('Open…', roleName='menu item')
+    click('test-links.pdf', roleName='table cell')
+    click('Open', roleName='push button')
 
-# Save a Copy
-focus.frame('test-links.pdf')
-click('File', roleName='menu')
-click('Save a Copy…', roleName='menu item')
-click('Cancel', roleName='push button')
+    # Save a Copy
+    focus.frame('test-links.pdf')
+    click('File', roleName='menu')
+    click('Save a Copy…', roleName='menu item')
+    click('Cancel', roleName='push button')
 
-# Print
-focus.frame('test-links.pdf')
-click('File', roleName='menu')
-click('Print…', roleName='menu item')
-focus.dialog('Print')
-click('Cancel', roleName='push button')
+    # Print
+    focus.frame('test-links.pdf')
+    click('File', roleName='menu')
+    click('Print…', roleName='menu item')
+    focus.dialog('Print')
+    click('Cancel', roleName='push button')
 
-# Properties
-focus.frame('test-links.pdf')
-click('File', roleName='menu')
-click('Properties', roleName='menu item')
-click('Fonts', roleName='page tab')
-click('General', roleName='page tab')
-focus.dialog('Properties')
-click('Close', roleName='push button')
+    # Properties
+    focus.frame('test-links.pdf')
+    click('File', roleName='menu')
+    click('Properties', roleName='menu item')
+    click('Fonts', roleName='page tab')
+    click('General', roleName='page tab')
+    focus.dialog('Properties')
+    click('Close', roleName='push button')
 
-# Close All Windows
-focus.frame('test-links.pdf')
-click('File', roleName='menu')
-click('Close All Windows', roleName='menu item')
+    # Close All Windows
+    focus.frame('test-links.pdf')
+    click('File', roleName='menu')
+    click('Close All Windows', roleName='menu item')
+
+except:
+    bail()

--- a/test/testFileMenu.py
+++ b/test/testFileMenu.py
@@ -7,13 +7,12 @@ from testCommon import run_app, bail
 from dogtail.procedural import *
 
 try:
-    run_app()
+    run_app(file='test-links.pdf')
 
     # Open a file
     click('File', roleName='menu')
     click('Open…', roleName='menu item')
-    click('test-links.pdf', roleName='table cell')
-    click('Open', roleName='push button')
+    click('Cancel', roleName='push button')
 
     # Save a Copy
     focus.frame('test-links.pdf')

--- a/test/testGoMenu.py
+++ b/test/testGoMenu.py
@@ -2,36 +2,35 @@
 
 # This test opens the Go menu and test menu items.
 
-import os
-os.environ['LANG']='C'
+from testCommon import run_app, bail
 
 from dogtail.procedural import *
 
-import dogtail.config
-dogtail.config.config.logDebugToStdOut = True
-dogtail.config.config.logDebugToFile = False
+try:
+    run_app()
 
-run('xreader')
+    # Open a file
+    click('File', roleName='menu')
+    click('Open…', roleName='menu item')
+    click('test-links.pdf', roleName='table cell')
+    click('Open', roleName='push button')
 
-# Open a file
-click('File', roleName='menu')
-click('Open…', roleName='menu item')
-click('test-links.pdf', roleName='table cell')
-click('Open', roleName='push button')
+    focus.frame('test-links.pdf')
+    click('Go', roleName='menu')
+    click('Next Page', roleName='menu item')
 
-focus.frame('test-links.pdf')
-click('Go', roleName='menu')
-click('Next Page', roleName='menu item')
+    click('Go', roleName='menu')
+    click('Previous Page', roleName='menu item')
 
-click('Go', roleName='menu')
-click('Previous Page', roleName='menu item')
+    click('Go', roleName='menu')
+    click('Last Page', roleName='menu item')
 
-click('Go', roleName='menu')
-click('Last Page', roleName='menu item')
+    click('Go', roleName='menu')
+    click('First Page', roleName='menu item')
 
-click('Go', roleName='menu')
-click('First Page', roleName='menu item')
+    # Close
+    click('File', roleName='menu')
+    click('Close', roleName='menu item')
 
-# Close
-click('File', roleName='menu')
-click('Close', roleName='menu item')
+except:
+    bail()

--- a/test/testGoMenu.py
+++ b/test/testGoMenu.py
@@ -7,13 +7,7 @@ from testCommon import run_app, bail
 from dogtail.procedural import *
 
 try:
-    run_app()
-
-    # Open a file
-    click('File', roleName='menu')
-    click('Open…', roleName='menu item')
-    click('test-links.pdf', roleName='table cell')
-    click('Open', roleName='push button')
+    run_app(file='test-links.pdf')
 
     focus.frame('test-links.pdf')
     click('Go', roleName='menu')

--- a/test/testHelpMenu.py
+++ b/test/testHelpMenu.py
@@ -2,25 +2,27 @@
 
 # This test opens the Help menu and runs through the menu items.
 
-import os
-os.environ['LANG']='C'
+from testCommon import run_app, bail
 
 from dogtail.procedural import *
 
-run('xreader')
+try:
+    run_app()
 
-click('Help', roleName='menu')
-click('About', roleName='menu item')
-focus.dialog('About Xreader')
-click('License', roleName='toggle button')
-click('Close', roleName='push button')
+    click('Help', roleName='menu')
+    click('About', roleName='menu item')
+    focus.dialog('About Xreader')
+    click('License', roleName='toggle button')
+    click('Close', roleName='push button')
 
-focus.frame('Recent Documents')
-click('Help', roleName='menu')
-click('Contents', roleName='menu item')
+    focus.frame('Recent Documents')
+    click('Help', roleName='menu')
+    click('Contents', roleName='menu item')
 
-keyCombo('<Control>w')
+    keyCombo('<Control>w')
 
-focus.frame('Recent Documents')
-click('File', roleName='menu')
-click('Close', roleName='menu item')
+    focus.frame('Recent Documents')
+    click('File', roleName='menu')
+    click('Close', roleName='menu item')
+except:
+    bail()

--- a/test/testZoom.py
+++ b/test/testZoom.py
@@ -2,32 +2,31 @@
 
 # This test opens the View menu and test zoom features.
 
-import os
-os.environ['LANG']='C'
+from testCommon import run_app, bail
 
 from dogtail.procedural import *
 
-import dogtail.config
-dogtail.config.config.logDebugToStdOut = True
-dogtail.config.config.logDebugToFile = False
+try:
+    run_app()
 
-run('xreader')
+    # Open a file
+    click('File', roleName='menu')
+    click('Open…', roleName='menu item')
+    click('test-links.pdf', roleName='table cell')
+    click('Open', roleName='push button')
 
-# Open a file
-click('File', roleName='menu')
-click('Open…', roleName='menu item')
-click('test-links.pdf', roleName='table cell')
-click('Open', roleName='push button')
+    # Zoom In
+    focus.frame('test-links.pdf')
+    click('View', roleName='menu')
+    click('Zoom In', roleName='menu item')
 
-# Zoom In
-focus.frame('test-links.pdf')
-click('View', roleName='menu')
-click('Zoom In', roleName='menu item')
+    # Zoom Out
+    click('View', roleName='menu')
+    click('Zoom Out', roleName='menu item')
 
-# Zoom Out
-click('View', roleName='menu')
-click('Zoom Out', roleName='menu item')
+    # Close
+    click('File', roleName='menu')
+    click('Close', roleName='menu item')
 
-# Close
-click('File', roleName='menu')
-click('Close', roleName='menu item')
+except:
+    bail()

--- a/test/testZoom.py
+++ b/test/testZoom.py
@@ -7,13 +7,7 @@ from testCommon import run_app, bail
 from dogtail.procedural import *
 
 try:
-    run_app()
-
-    # Open a file
-    click('File', roleName='menu')
-    click('Open…', roleName='menu item')
-    click('test-links.pdf', roleName='table cell')
-    click('Open', roleName='push button')
+    run_app(file='test-links.pdf')
 
     # Zoom In
     focus.frame('test-links.pdf')


### PR DESCRIPTION
Summary of changes:
* Tests: use build target rather than executable name for dependency
* Debian builds no longer run the tests by default. If you want to run them, run `meson test` from the build directory.
* The option to enable or disable the tests is now removed as it's essentially pointless (since the test are only run when you run the test command).
* The tests currently use an option that's not available until meson 0.46 so the tests are not set up for previous versions. The only side effect to this is that trying to run the tests through `meson test` will do nothing on older versions.
* factor out the boilerplate into it's own file (this will make it easier to maintain)
* added a try/catch block around all the commands so that if something goes wrong it quits the application and then returns an exit code of 1 from the script to indicate failure
* Uses the built version of xreader for the tests rather than system version. This ensures that we're testing the right version and that the tests will work even if we don't have xreader installed.
* testEditMenu.py and testFileMenu.py: open file with arg to prevent error
* Tests: extend the timeout from 30 seconds to 2 minutes