### PR TITLE
Copy metadata when a file is copied

### DIFF
--- a/shell/ev-metadata.c
+++ b/shell/ev-metadata.c
@@ -323,3 +323,28 @@ ev_is_metadata_supported_for_file (GFile *file)
 
 	return retval;
 }
+
+void
+ev_metadata_copy_to (EvMetadata  *metadata, GFile *file)
+{
+	GFileInfo *info;
+	GError    *error = NULL;
+
+	info = g_file_query_info (metadata->file, "metadata::*", 0, NULL, &error);
+	if (!info) {
+		g_warning ("%s", error->message);
+		g_error_free (error);
+
+		return;
+	}
+
+	g_file_set_attributes_async (file,
+				     info,
+				     0,
+				     G_PRIORITY_DEFAULT,
+				     NULL,
+				     (GAsyncReadyCallback)metadata_set_callback,
+				     metadata);
+
+	g_object_unref (info);
+}

--- a/shell/ev-metadata.h
+++ b/shell/ev-metadata.h
@@ -67,6 +67,9 @@ gboolean    ev_metadata_has_key               (EvMetadata  *metadata,
 
 gboolean    ev_is_metadata_supported_for_file (GFile       *file);
 
+void        ev_metadata_copy_to               (EvMetadata  *metadata,
+                                               GFile       *file);
+
 G_END_DECLS
 
 #endif /* EV_METADATA_H */

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -2928,6 +2928,12 @@ ev_window_save_job_cb (EvJob     *job,
                 EV_JOB_SAVE (job)->uri);
     } else {
         ev_window_add_recent (window, EV_JOB_SAVE (job)->uri);
+
+        GFile *dst = g_file_new_for_uri (EV_JOB_SAVE (job)->uri);
+	    if (dst && ev_is_metadata_supported_for_file (dst))
+	        ev_metadata_copy_to (window->priv->metadata, dst);
+
+	    g_object_unref (dst);
     }
 
     ev_window_clear_save_job (window);
@@ -2940,7 +2946,7 @@ ev_window_save_as (EvWindow *ev_window,
     /* FIXME: remote copy should be done here rather than in the save job,
      * so that we can track progress and cancel the operation
      */
-		ev_window_clear_save_job (ev_window);
+    ev_window_clear_save_job (ev_window);
     ev_window->priv->save_job = ev_job_save_new (ev_window->priv->document,
             uri, ev_window->priv->uri);
     g_signal_connect (ev_window->priv->save_job, "finished",
@@ -3571,7 +3577,7 @@ ev_window_check_document_modified (EvWindow *ev_window)
     int result = gtk_dialog_run (GTK_DIALOG (dialog));
     gtk_widget_destroy (GTK_WIDGET (dialog));
 
-    if (result == GTK_RESPONSE_YES) 
+    if (result == GTK_RESPONSE_YES)
         return !ev_window_cmd_save_as (NULL, ev_window);
     else if (result == GTK_RESPONSE_NO)
     	return FALSE;
@@ -3579,7 +3585,7 @@ ev_window_check_document_modified (EvWindow *ev_window)
         ev_window_save (ev_window);
         return FALSE;
     }
-    	
+
     return TRUE;
 }
 


### PR DESCRIPTION
The metadata are now copied also when a copy is done. In particular, bookmarks are kept when a file is copied

N.B. I didn't reproduce the issue when a file is renamed. The bookmarks are kept in my case.
I reproduced the bug when I copy the file either by xreader or by nemo. This PR fix the bug when the file is copied by xreader. When the file is copied by nemo should be fixed in nemo sources. We should see if the metadata are kept during the copy with other softwares (like Dolphin?)

IssueID #154 and #372