### PR TITLE
Fix for issue 410 by removing search text

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5454,8 +5454,11 @@ find_bar_visibility_changed_cb (EggFindBar *find_bar,
 
         if (visible)
             ev_window_search_start (ev_window);
-        else
+        else 
+        {
             egg_find_bar_set_status_text (EGG_FIND_BAR (ev_window->priv->find_bar), NULL);
+            egg_find_bar_set_search_string (EGG_FIND_BAR (ev_window->priv->find_bar), NULL);
+        }
     }
 }
 


### PR DESCRIPTION
This PR resolves #410. The issue was with the highlighting of the search text. Easiest fix was to remove the search text on when the find bar is disabled. Evince mirrors this same functionality as well.

If anything needs to be updated, edited, or removed for this PR, just let me know and I'll make the change accordingly. Thanks.