### PR TITLE
Get toolbar visibility from GtkRevealer when saving view metadata

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -4396,7 +4396,7 @@ ev_window_cmd_edit_save_settings (GtkAction *action,
         g_settings_set_double (settings, "zoom", zoom);
     }
     g_settings_set_boolean (settings, "show-toolbar",
-            gtk_widget_get_visible (priv->toolbar));
+            gtk_revealer_get_reveal_child( GTK_REVEALER (ev_window->priv->toolbar_revealer)));
     g_settings_set_boolean (settings, "show-sidebar",
             gtk_widget_get_visible (priv->sidebar));
     g_settings_set_int (settings, "sidebar-size",


### PR DESCRIPTION
Fixes #261

Note: we might add the toolbar and sidebar visibility to the document model. Also I personally would even completely reconsider saving view metadata like toolbar and sidebar visibility per file.