### PR TITLE
Added logic to fix issue of Tab key toggling checkboxes

### DIFF
--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -186,6 +186,9 @@ struct _EvView {
 	/* Common for button press handling */
 	int pressed_button;
 
+    /* Key bindings propagation */
+    gboolean key_binding_handled;
+
 	/* Information for middle clicking and dragging around. */
 	DragInfo drag_info;
 	
@@ -253,6 +256,7 @@ struct _EvViewClass {
 	void    (*annot_added)            (EvView         *view,
 					   EvAnnotation   *annot);
 	void    (*layers_changed)         (EvView         *view);
+	void    (*activate)         (EvView         *view);
 };
 
 void _get_page_size_for_scale_and_rotation (EvDocument *document,


### PR DESCRIPTION
This PR fixes #380.

Tabbing over a checkbox in a PDF form no longer toggles the state of the checkbox.

If anything on this PR needs to be changed, updated, or removed, just let me know and I'll make the changes accordingly. Thanks.