### PR TITLE
Implement #146: Add setting to hide/show menubar

### DIFF
--- a/data/org.x.reader.gschema.xml
+++ b/data/org.x.reader.gschema.xml
@@ -41,6 +41,9 @@
     <key name="show-sidebar" type="b">
       <default>true</default>
     </key>
+    <key name="show-menubar" type="b">
+      <default>true</default>
+    </key>
     <key name="window-ratio" type="(dd)">
       <default>(0., 0.)</default>
     </key>

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -4429,6 +4429,8 @@ ev_window_cmd_edit_save_settings (GtkAction *action,
         zoom *= 72.0 / get_screen_dpi (ev_window);
         g_settings_set_double (settings, "zoom", zoom);
     }
+    g_settings_set_boolean (settings, "show-menubar",
+            ((priv->chrome & EV_CHROME_MENUBAR) != 0));
     g_settings_set_boolean (settings, "show-toolbar",
             gtk_widget_get_visible (priv->toolbar));
     g_settings_set_boolean (settings, "show-sidebar",

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -705,6 +705,11 @@ update_chrome_actions (EvWindow *window)
     GtkActionGroup *action_group = priv->action_group;
     GtkAction *action;
 
+    action = gtk_action_group_get_action(action_group, "ViewMenubar");
+    g_signal_handlers_block_by_func (action, G_CALLBACK (ev_window_view_menubar_cb), window);
+    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), (priv->chrome & EV_CHROME_MENUBAR != 0));
+    g_signal_handlers_unblock_by_func (action, G_CALLBACK (ev_window_view_menubar_cb), window);
+
     action= gtk_action_group_get_action (action_group, "ViewToolbar");
     g_signal_handlers_block_by_func
     (action, G_CALLBACK (ev_window_view_toolbar_cb), window);
@@ -1296,6 +1301,7 @@ static void
 setup_view_from_metadata (EvWindow *window)
 {
     gboolean presentation;
+    gboolean show_menubar;
 
     if (!window->priv->metadata)
         return;
@@ -1310,6 +1316,13 @@ setup_view_from_metadata (EvWindow *window)
                 ev_window_run_presentation (window);
             }
         }
+    }
+
+    /* Menubar */
+    if(ev_metadata_get_boolean (window->priv->metadata, "show_menubar", &show_menubar)) {
+        gtk_widget_show(window->priv->menubar);
+    } else {
+        gtk_widget_hide(window->priv->menubar);
     }
 }
 
@@ -7503,6 +7516,9 @@ ev_window_init (EvWindow *ev_window)
 	 * menubar together with the app menu.
 	 */
 	gtk_application_window_set_show_menubar (GTK_APPLICATION_WINDOW (ev_window), FALSE);
+
+    ev_window->priv->menubar_skip_release = FALSE;
+    ev_window->priv->menubar_show_queued = FALSE;
 
     ev_window->priv->model = ev_document_model_new ();
 

--- a/shell/xreader-ui.xml
+++ b/shell/xreader-ui.xml
@@ -32,6 +32,7 @@
     </menu>
 
     <menu name="ViewMenu" action="View">
+      <menuitem name="ViewMenubarMenu" action="ViewMenubar"/>
       <menuitem name="ViewToolbarMenu" action="ViewToolbar"/>
       <menuitem name="ViewSidebarMenu" action="ViewSidebar"/>
       <separator/>


### PR DESCRIPTION
This implements feature request issue #146.
It adds an menu item to hide the menubar, which can be shown via the alt key if necessary.

Parts of the code were taken from Nemo.