### PR TITLE
Convert parse_mimetypes from returning gchar** to void

### DIFF
--- a/shell/ev-application.c
+++ b/shell/ev-application.c
@@ -743,7 +743,7 @@ handle_get_window_list_cb (EvXreaderApplication   *object,
             if (!EV_IS_WINDOW (l->data))
                 continue;
 
-                g_ptr_array_add (paths, (gpointer) ev_window_get_dbus_object_path (EV_WINDOW (l->data)));
+            g_ptr_array_add (paths, (gpointer) ev_window_get_dbus_object_path (EV_WINDOW (l->data)));
         }
 
         g_ptr_array_add (paths, NULL);
@@ -990,11 +990,9 @@ ev_application_class_init (EvApplicationClass *ev_application_class)
 #endif
         }
 
-static gchar **
+static void
 parse_mimetypes (void)
 {
-    gchar **ret;
-
     supported_mimetypes = g_strsplit (SUPPORTED_MIMETYPES, ";", -1);
 }
 


### PR DESCRIPTION
`parse_mimetypes` was supposed to return a gchar**, but it actually just stores the result in the global variable `parse_mimetypes`. To make this clearer, this commit modifies the return type of `parse_mimetypes` to be void, as the function never actually returned anything. This prevents undefined behavior in case anyone would actually try to store the returned value.
Also, the unused variable result has been removed and the indentation was fixed in one line.
This fixes https://github.com/linuxmint/xreader/issues/442