### PR TITLE
Display number of occurrences in searchbar over whole document

### DIFF
--- a/libview/ev-jobs.c
+++ b/libview/ev-jobs.c
@@ -1410,6 +1410,8 @@ ev_job_find_run (EvJob *job)
 		job_find->pages[job_find->current_page] = matches;
 	}
 
+	job_find->total_count += g_list_length(job_find->pages[job_find->current_page]);
+	
 	g_signal_emit (job_find, job_find_signals[FIND_UPDATED], 0, job_find->current_page);
 		       
 	job_find->current_page = (job_find->current_page + 1) % job_find->n_pages;

--- a/libview/ev-jobs.h
+++ b/libview/ev-jobs.h
@@ -349,6 +349,7 @@ struct _EvJobFind
 	gint start_page;
 	gint current_page;
 	gint n_pages;
+	guint total_count;
 	GList **pages;
 	guint *results;
 	gchar *text;

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5500,10 +5500,10 @@ ev_window_update_find_status_message (EvWindow *ev_window)
             /* TRANS: Sometimes this could be better translated as
                "%d hit(s) on this page".  Therefore this string
                contains plural cases. */
-            message = g_strdup_printf (ngettext ("%d found on this page",
-                    "%d found on this page",
-                    n_results),
-                    n_results);
+            message = g_strdup_printf (ngettext ("%d found on this page (%d total)",
+                             "%d found on this page (%d total)",
+                             n_results),
+                             n_results, job_find->total_count);
         } else {
             message = g_strdup (_("Not found"));
         }


### PR DESCRIPTION
Hello there,
I needed the feature in #455  very much, too. A large part of it was already done in the previous code. I just added a variable named total_count and tried to show it right next to the result in searches. It could be a nice feature. 
![xreader](https://user-images.githubusercontent.com/19881231/109672747-624d4f80-7b86-11eb-8a60-ae1b2f9b1307.png)
