### PR TITLE
fix segfault in epub backend when opening a filename containing a hash

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1630,7 +1630,7 @@ page_set_function(linknode *Link, GList *contentList)
 	contentListNode *pagedata;
 
 	guint flag=0;
-	while (!flag) {
+	while (!flag && listiter) {
 		pagedata = listiter->data;
 		if (link_present_on_page(Link->pagelink, pagedata->value)) {
 			flag=1;


### PR DESCRIPTION
Check if end of list is reached before attempting to dereference `data`