### PR TITLE
Fix/issue 485 - fix unescaping of '#'

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1630,7 +1630,7 @@ page_set_function(linknode *Link, GList *contentList)
 	contentListNode *pagedata;
 
 	guint flag=0;
-	while (!flag) {
+	while (!flag && listiter) {
 		pagedata = listiter->data;
 		if (link_present_on_page(Link->pagelink, pagedata->value)) {
 			flag=1;

--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1283,7 +1283,8 @@ setup_document_children(EpubDocument *epub_document,xmlNodePtr node)
             pagelink->str = g_uri_unescape_string (escaped,NULL);
             g_free(escaped);
 
-            if ((end = g_strrstr(pagelink->str,"#")) != NULL) {
+            // cut off fragment after '#', only in the last segment of path
+            if ((end = g_strrstr(pagelink->str,"#")) != NULL && (end > g_strrstr(pagelink->str,"/"))) {
 	            fragment = g_strdup(g_strrstr(pagelink->str,"#"));
 	            *end = '\0';
             }
@@ -1630,7 +1631,7 @@ page_set_function(linknode *Link, GList *contentList)
 	contentListNode *pagedata;
 
 	guint flag=0;
-	while (!flag && listiter) {
+	while (!flag && listiter != NULL) {
 		pagedata = listiter->data;
 		if (link_present_on_page(Link->pagelink, pagedata->value)) {
 			flag=1;

--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -650,9 +650,9 @@ ev_view_presentation_goto_window_create (EvViewPresentation *pview)
 	GtkWindow *toplevel, *goto_window;
 
 	toplevel = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (pview)));
-	goto_window = GTK_WINDOW (pview->goto_window);
 
 	if (pview->goto_window) {
+               goto_window = GTK_WINDOW (pview->goto_window);
 		if (gtk_window_has_group (toplevel))
 			gtk_window_group_add_window (gtk_window_get_group (toplevel), goto_window);
 		else if (gtk_window_has_group (goto_window))
@@ -662,6 +662,7 @@ ev_view_presentation_goto_window_create (EvViewPresentation *pview)
 	}
 
 	pview->goto_window = gtk_window_new (GTK_WINDOW_POPUP);
+	goto_window = GTK_WINDOW (pview->goto_window);
 	gtk_window_set_screen (goto_window, gtk_widget_get_screen (GTK_WIDGET (pview)));
 
 	if (gtk_window_has_group (toplevel))


### PR DESCRIPTION
epub backend uses hash '#' to look for anchors within a page.
To this end it unescapes the in the filename.
This fix makes sure that `#`:

- is NOT unescaped to e.g. `file:///tmp/xreader-503239/2019%20#1.epubBR4320/text/part0000_split_001.xhtml` because it is not in the rightmost segment
- is unescaped to e.g. `file:///tmp/xreader-503239/2019%20%231.epubBR4320/text/part0002.xhtml#1T140-853fc95530a4497cbe3bd019f4e9938b` only in the rightmost segment