### PR TITLE
Behaviour of search keys

### DIFF
--- a/shell/eggfindbar.c
+++ b/shell/eggfindbar.c
@@ -271,13 +271,6 @@ set_focus_cb (GtkWidget *window,
       widget = gtk_widget_get_parent (widget);
     }
 
-  /* if widget == bar, the new focus widget is in the bar, so we
-   * don't deactivate.
-   */
-  if (widget != wbar)
-    {
-      g_signal_emit (bar, find_bar_signals[CLOSE], 0);
-    }
 }
 
 static void

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -4029,13 +4029,6 @@ static void
 ev_window_cmd_edit_find (GtkAction *action,
                          EvWindow  *ev_window)
 {
-    if (gtk_widget_is_visible (ev_window->priv->find_bar))
-    {
-        update_chrome_flag (ev_window, EV_CHROME_FINDBAR, FALSE);
-        update_chrome_visibility (ev_window);
-        return;
-    }
-
     if (ev_window->priv->document == NULL || !EV_IS_DOCUMENT_FIND (ev_window->priv->document)) {
         g_error ("Find action should be insensitive since document doesn't support find");
         return;
@@ -4923,6 +4916,12 @@ ev_window_cmd_escape (GtkAction *action,
 
     if (window->priv->document && !window->priv->document->iswebdocument && window->priv->view)
         ev_view_autoscroll_stop (EV_VIEW (window->priv->view));
+
+    if (gtk_widget_is_visible (window->priv->find_bar)) {
+        update_chrome_flag (window, EV_CHROME_FINDBAR, FALSE);
+        update_chrome_visibility (window);
+        return;
+    }
 
     widget = gtk_window_get_focus (GTK_WINDOW (window));
     if (widget && gtk_widget_get_ancestor (widget, EGG_TYPE_FIND_BAR)) {
@@ -8059,6 +8058,10 @@ ev_window_init (EvWindow *ev_window)
     g_signal_connect (ev_window->priv->find_bar,
             "next",
             G_CALLBACK (find_bar_next_cb),
+            ev_window);
+    g_signal_connect (ev_window->priv->find_bar,
+            "close",
+            G_CALLBACK (find_bar_close_cb),
             ev_window);
     g_signal_connect (ev_window->priv->find_bar,
             "notify::search-string",


### PR DESCRIPTION
Hello there,
One of the biggest problems I have while using xreader is that when searching, the `ctrl+f` key functions as a toggle search box instead of focusing search text. However, this is not the case with any other pdf reader. For example:
- Evince
- Okular
- Firefox reader
- most other readers

The expected behavior here is to open the search box when `ctrl+f` is pressed for the first time, and the next time `ctrl+f` is pressed should be focused the search string . At the same time, when we press the `espace` key, it should close search box. I wanted to fix them with this pull request.