### PR TITLE
Annotation icons added to popup menu

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -6523,9 +6523,9 @@ static const GtkActionEntry view_popup_entries [] = {
 	  NULL, G_CALLBACK (ev_view_popup_cmd_save_image_as) },
 	{ "CopyImage", NULL, N_("Copy _Image"), NULL,
 	  NULL, G_CALLBACK (ev_view_popup_cmd_copy_image) },
-	{ "AnnotProperties", NULL, N_("Annotation Properties…"), NULL,
+	{ "AnnotProperties", "xapp-format-text-highlight-symbolic" , N_("Annotation Properties…"), NULL,
 	  NULL, G_CALLBACK (ev_view_popup_cmd_annot_properties) },
-	{ "RemoveAnnotation", NULL, N_("Remove Annotation"), NULL,
+	{ "RemoveAnnotation", "window-close-symbolic", N_("Remove Annotation"), NULL,
 	  NULL, G_CALLBACK (ev_view_popup_cmd_remove_annotation) }
 };
 


### PR DESCRIPTION
I added icons to popup menu for annotations.
before:
![before](https://user-images.githubusercontent.com/19881231/120904219-c7b44f00-c653-11eb-8967-ca6a82e797c3.png)
after:
![after](https://user-images.githubusercontent.com/19881231/120904221-cb47d600-c653-11eb-9f16-2e7215eaf707.png)
