### PR TITLE
Attachment popup fix

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5411,10 +5411,10 @@ view_menu_annot_popup (EvWindow     *ev_window,
         }
     }
 
-    ev_window_set_action_visible (ev_window->priv->view_popup_action_group,
+    ev_window_set_action_visible (ev_window->priv->attachment_popup_action_group,
                                   "OpenAttachment",
                                   show_annot);
-    ev_window_set_action_visible (ev_window->priv->view_popup_action_group,
+    ev_window_set_action_visible (ev_window->priv->attachment_popup_action_group,
                                   "SaveAttachmentAs",
                                   show_annot);
 }


### PR DESCRIPTION
After this PR #491 ,  I realized while we don't have an attachment, the popup entry shows `Open attachment` and `Save attachment`. Also when you run `xreader` and  right click you will get errors like these:
```
(xreader:177608): Gtk-CRITICAL **: 13:52:34.622: gtk_action_set_visible: assertion 'GTK_IS_ACTION (action)' failed
(xreader:177608): Gtk-CRITICAL **: 13:52:34.622: gtk_action_set_visible: assertion 'GTK_IS_ACTION (action)' failed
```
 The reason, these entries do not belong to `view_popup_action_group`. They belong to `attachment_popup_action_group`.

They're populated in `attachment_popup_entries`.
```c
static const GtkActionEntry attachment_popup_entries [] = {
        { "OpenAttachment", "document-open-symbolic", N_("_Open Attachment"), NULL,
                NULL, G_CALLBACK (ev_attachment_popup_cmd_open_attachment) },
        { "SaveAttachmentAs", "document-save-as-symbolic", N_("_Save Attachment As…"), NULL,
                NULL, G_CALLBACK (ev_attachment_popup_cmd_save_attachment_as) },
};
```

```c
action_group = gtk_action_group_new ("AttachmentPopupActions");
    ev_window->priv->attachment_popup_action_group = action_group;
    gtk_action_group_set_translation_domain (action_group, NULL);
    gtk_action_group_add_actions (action_group, attachment_popup_entries,
            G_N_ELEMENTS (attachment_popup_entries),
            ev_window);
```