### PR TITLE
Update the README.

### DIFF
--- a/README
+++ b/README
@@ -102,7 +102,7 @@ Hacking
 -------
 
 Our Coding Guidelines can be found under
-https://www.gitbook.com/book/linuxmint/coding-guidelines.
+https://linuxmint-developer-guide.readthedocs.io/en/latest/guidelines.html
 
 
 Optional Backend Libraries


### PR DESCRIPTION
Under the 'Hacking' section, the indicated link does not work. It
redirects to the gitbook site, but does not allow the user to peruse the
indicated guidelines.

A google search with the text of that section suggests that the
following link (https://linuxmint-developer-guide.readthedocs.io/en/latest/guidelines.html)
may actually be the link for the guidelines.

This commit updates the link in the Hacking section, if the link is actually the
current coding guidelines for linuxmint.