### PR TITLE
build/i18n: migrate from intltool to gettext

### DIFF
--- a/backend/comics/comicsdocument.xreader-backend.desktop.in
+++ b/backend/comics/comicsdocument.xreader-backend.desktop.in
@@ -1,4 +1,4 @@
 [Xreader Backend]
 Module=comicsdocument
-_TypeDescription=Comic Books
+TypeDescription=Comic Books
 MimeType=application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;

--- a/backend/comics/meson.build
+++ b/backend/comics/meson.build
@@ -20,11 +20,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'comics_backend',
-    input: 'comicsdocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'comicsdocument.xreader-backend.desktop.in',
     output: 'comicsdocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/djvu/djvudocument.xreader-backend.desktop.in
+++ b/backend/djvu/djvudocument.xreader-backend.desktop.in
@@ -1,4 +1,4 @@
 [Xreader Backend]
 Module=djvudocument
-_TypeDescription=DjVu Documents
+TypeDescription=DjVu Documents
 MimeType=image/vnd.djvu;image/vnd.djvu+multipage

--- a/backend/djvu/meson.build
+++ b/backend/djvu/meson.build
@@ -26,11 +26,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'djvu_backend',
-    input: 'djvudocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'djvudocument.xreader-backend.desktop.in',
     output: 'djvudocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/dvi/dvidocument.xreader-backend.desktop.in
+++ b/backend/dvi/dvidocument.xreader-backend.desktop.in
@@ -1,4 +1,4 @@
 [Xreader Backend]
 Module=dvidocument
-_TypeDescription=DVI Documents
+TypeDescription=DVI Documents
 MimeType=application/x-dvi;application/x-bzdvi;application/x-gzdvi

--- a/backend/dvi/meson.build
+++ b/backend/dvi/meson.build
@@ -31,11 +31,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'dvi_backend',
-    input: 'dvidocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'dvidocument.xreader-backend.desktop.in',
     output: 'dvidocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/epub/epubdocument.xreader-backend.desktop.in
+++ b/backend/epub/epubdocument.xreader-backend.desktop.in
@@ -1,4 +1,4 @@
 [Xreader Backend]
 Module=epubdocument
-_TypeDescription=epub Documents
+TypeDescription=epub Documents
 MimeType=application/epub+zip;

--- a/backend/epub/meson.build
+++ b/backend/epub/meson.build
@@ -25,11 +25,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'epub_backend',
-    input: 'epubdocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'epubdocument.xreader-backend.desktop.in',
     output: 'epubdocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/pdf/meson.build
+++ b/backend/pdf/meson.build
@@ -20,11 +20,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'pdf_backend',
-    input: 'pdfdocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'pdfdocument.xreader-backend.desktop.in',
     output: 'pdfdocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/pdf/pdfdocument.xreader-backend.desktop.in
+++ b/backend/pdf/pdfdocument.xreader-backend.desktop.in
@@ -1,5 +1,5 @@
 [Xreader Backend]
 Module=pdfdocument
 Resident=true
-_TypeDescription=PDF Documents
+TypeDescription=PDF Documents
 MimeType=application/pdf;application/x-bzpdf;application/x-gzpdf;application/x-xzpdf;application/x-ext-pdf;

--- a/backend/pixbuf/meson.build
+++ b/backend/pixbuf/meson.build
@@ -20,11 +20,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'pixbuf_backend',
-    input: 'pixbufdocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'pixbufdocument.xreader-backend.desktop.in',
     output: 'pixbufdocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/pixbuf/pixbufdocument.xreader-backend.desktop.in
+++ b/backend/pixbuf/pixbufdocument.xreader-backend.desktop.in
@@ -1,4 +1,4 @@
 [Xreader Backend]
 Module=pixbufdocument
-_TypeDescription=Images
+TypeDescription=Images
 MimeType=image/*;

--- a/backend/ps/meson.build
+++ b/backend/ps/meson.build
@@ -21,11 +21,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'ps_backend',
-    input: 'psdocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'psdocument.xreader-backend.desktop.in',
     output: 'psdocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/ps/psdocument.xreader-backend.desktop.in
+++ b/backend/ps/psdocument.xreader-backend.desktop.in
@@ -1,5 +1,5 @@
 [Xreader Backend]
 Module=psdocument
 Resident=true
-_TypeDescription=PostScript Documents
+TypeDescription=PostScript Documents
 MimeType=application/postscript;application/x-bzpostscript;application/x-gzpostscript;image/x-eps;image/x-bzeps;image/x-gzeps

--- a/backend/tiff/meson.build
+++ b/backend/tiff/meson.build
@@ -24,11 +24,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'tiff_backend',
-    input: 'tiffdocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'tiffdocument.xreader-backend.desktop.in',
     output: 'tiffdocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/tiff/tiffdocument.xreader-backend.desktop.in
+++ b/backend/tiff/tiffdocument.xreader-backend.desktop.in
@@ -1,4 +1,4 @@
 [Xreader Backend]
 Module=tiffdocument
-_TypeDescription=Tiff Documents
+TypeDescription=Tiff Documents
 MimeType=image/tiff

--- a/backend/xps/meson.build
+++ b/backend/xps/meson.build
@@ -21,11 +21,12 @@ shared_module(
     install_dir: backendsdir,
 )
 
-custom_target(
-    'xps_backend',
-    input: 'xpsdocument.xreader-backend.in',
+i18n.merge_file(
+    input: 'xpsdocument.xreader-backend.desktop.in',
     output: 'xpsdocument.xreader-backend',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
+    args: ['--keyword=TypeDescription'],
     install: true,
     install_dir: backendsdir,
 )

--- a/backend/xps/xpsdocument.xreader-backend.desktop.in
+++ b/backend/xps/xpsdocument.xreader-backend.desktop.in
@@ -1,5 +1,5 @@
 [Xreader Backend]
 Module=xpsdocument
 Resident=true
-_TypeDescription=XPS Documents
+TypeDescription=XPS Documents
 MimeType=application/oxps;application/vnd.ms-xpsdocument

--- a/data/meson.build
+++ b/data/meson.build
@@ -31,20 +31,20 @@ desktop = configure_file(
     configuration: desktop_conf,
 )
 
-custom_target(
-    'desktop',
+i18n.merge_file(
     input: desktop,
     output: 'xreader.desktop',
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'desktop',
     install: true,
     install_dir: desktopdir,
 )
 
-appdata = custom_target(
-    'appdata',
+i18n.merge_file(
     input: 'xreader.appdata.xml.in',
     output: 'xreader.appdata.xml',
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    po_dir: po_dir,
+    type: 'xml',
     install: true,
     install_dir: join_paths(datadir, 'metainfo'),
 )

--- a/data/xreader.appdata.xml.in
+++ b/data/xreader.appdata.xml.in
@@ -4,8 +4,8 @@
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-2.0+</project_license>
  <name>Document Viewer</name>
- <_summary>A Document Viewer</_summary>
- <_description>
+ <summary>A Document Viewer</summary>
+ <description>
   <p>
    Xreader is a simple multi-page document viewer. It can display and
    print PostScript (PS), Encapsulated PostScript (EPS), DJVU, DVI,
@@ -14,7 +14,7 @@
    searching for text, copying text to the clipboard, hypertext navigation
    and table-of-contents bookmarks.
   </p>
- </_description>
+ </description>
  <url type="homepage">http://github.com/linuxmint/xreader</url>
  <project_group>Linux Mint</project_group>
 </component>

--- a/data/xreader.desktop.in.in
+++ b/data/xreader.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
-_Name=Document Viewer
-_Comment=View multi-page documents
+Name=Document Viewer
+Comment=View multi-page documents
 TryExec=xreader
 Exec=xreader %U
 StartupNotify=true

--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,8 @@ Section: x11
 Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
 Build-Depends: debhelper-compat (= 12),
+               gettext,
                gobject-introspection,
-               intltool,
                libdjvulibre-dev,
                libgail-3-dev,
                libgirepository1.0-dev,

--- a/makepot
+++ b/makepot
@@ -1,4 +1,20 @@
-cd po
-INTLTOOL_EXTRACT="/usr/bin/intltool-extract" XGETTEXT="/usr/bin/xgettext" srcdir=. /usr/bin/intltool-update --gettext-package xreader --pot
-mv xreader.pot ..
+#!/usr/bin/sh
 
+usage() {
+    echo "Usage: $0 [--help | <meson build dir>]"
+}
+
+if [ $# -ne 1 ] || [ $1 = "--help" ]; then
+    usage
+    exit 1
+fi
+
+if ! [ -d "$1" ]; then
+    echo "meson build dir '$1' does not exist"
+    exit 2
+fi
+
+echo "Generating po/xreader.pot ..."
+ninja -C "$1" xreader-pot || exit 1
+
+echo "Done. To update .po files run:\t ninja -C "$1" xreader-update-po"

--- a/meson.build
+++ b/meson.build
@@ -121,8 +121,6 @@ xreader_conf.set_quoted('SUPPORTED_MIMETYPES', xreader_mime_types) # This is gen
 # on some systems we need to find the math lib to make sure it builds
 math = cc.find_library('m', required: false)
 
-intltool_merge = find_program('intltool-merge')
-
 mathjax_directory = get_option('mathjax-directory')
 if mathjax_directory == ''
     foreach dir: [

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,19 +1,21 @@
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
-[encoding: UTF-8]
 backend/comics/comics-document.c
-[type: gettext/ini] backend/comics/comicsdocument.xreader-backend.in
+backend/comics/comicsdocument.xreader-backend.desktop.in
 backend/djvu/djvu-document.c
-[type: gettext/ini] backend/djvu/djvudocument.xreader-backend.in
+backend/djvu/djvudocument.xreader-backend.desktop.in
 backend/dvi/dvi-document.c
-[type: gettext/ini] backend/dvi/dvidocument.xreader-backend.in
+backend/dvi/dvidocument.xreader-backend.desktop.in
 backend/epub/epub-document.c
-[type: gettext/ini] backend/epub/epubdocument.xreader-backend.in
+backend/epub/epubdocument.xreader-backend.desktop.in
 backend/pdf/ev-poppler.cc
-[type: gettext/ini] backend/pdf/pdfdocument.xreader-backend.in
+backend/pdf/pdfdocument.xreader-backend.desktop.in
 backend/ps/ev-spectre.c
-[type: gettext/ini] backend/ps/psdocument.xreader-backend.in
+backend/ps/psdocument.xreader-backend.desktop.in
 backend/tiff/tiff-document.c
+backend/tiff/tiffdocument.xreader-backend.desktop.in
+backend/xps/xps-document.c
+backend/xps/xpsdocument.xreader-backend.desktop.in
 libdocument/ev-attachment.c
 libdocument/ev-document-factory.c
 libdocument/ev-file-helpers.c
@@ -43,7 +45,7 @@ shell/ev-keyring.c
 shell/ev-open-recent-action.c
 shell/ev-password-view.c
 shell/ev-preferences-dialog.c
-[type: gettext/glade]shell/ev-preferences-dialog.ui
+shell/ev-preferences-dialog.ui
 shell/ev-properties-dialog.c
 shell/ev-properties-fonts.c
 shell/ev-properties-license.c

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,4 +1,3 @@
-data/xreader.desktop.in
 backend/dvi/mdvi-lib/dviread.c
 backend/dvi/mdvi-lib/font.c
 backend/dvi/mdvi-lib/fontmap.c

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,3 +1,4 @@
 i18n.gettext(meson.project_name(),
-    preset: 'glib'
+    preset: 'glib',
+    args: ['--keyword=TypeDescription'],
 )


### PR DESCRIPTION
Replace intltool with gettext for translations.
This required some more file renames for the backends,
to let gettext detect the metadata files' type.

The makepot script has been updated to use the generated meson target `xreader-pot`
to generate the .pot file (and tells how to update .po files)

This commit also fixes:
* translate the `name` attribute in `xreader.appdata.xml`
* make backend metadata translatable for TIFF and XPS documents
  (visible in "Open" dialog) by adding them to `POTFILES.in`

#### ~TODO~
* ~fix translation of the description in `xreader.appdata.xml`~ See my next comment

~If you have any ideas how to correctly fix the above mentioned TODO, please tell me. The translations exist, but won't be merged anymore.~