### PR TITLE
Fix some build warnings

### DIFF
--- a/libdocument/ev-document-type-builtins.c.template
+++ b/libdocument/ev-document-type-builtins.c.template
@@ -15,7 +15,7 @@
 GType
 @enum_name@_get_type (void)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
+  static gsize g_define_type_id__volatile = 0;
  
   if (g_once_init_enter (&g_define_type_id__volatile)) {
     static const G@Type@Value values[] = {

--- a/libview/ev-job-scheduler.c
+++ b/libview/ev-job-scheduler.c
@@ -30,7 +30,7 @@ typedef struct _EvSchedulerJob {
 G_LOCK_DEFINE_STATIC(job_list);
 static GSList *job_list = NULL;
 
-static volatile EvJob *running_job = NULL;
+static EvJob *running_job = NULL;
 
 static gpointer ev_job_thread_proxy               (gpointer        data);
 static void     ev_scheduler_thread_job_cancelled (EvSchedulerJob *job,
@@ -56,12 +56,12 @@ ev_job_queue_push (EvSchedulerJob *job,
 		   EvJobPriority   priority)
 {
 	ev_debug_message (DEBUG_JOBS, "%s priority %d", EV_GET_TYPE_NAME (job->job), priority);
-	
+
 	g_mutex_lock (&job_queue_mutex);
 
 	g_queue_push_tail (job_queue[priority], job);
 	g_cond_broadcast (&job_queue_cond);
-	
+
 	g_mutex_unlock (&job_queue_mutex);
 }
 
@@ -70,7 +70,7 @@ ev_job_queue_get_next_unlocked (void)
 {
 	gint i;
 	EvSchedulerJob *job = NULL;
-	
+
 	for (i = EV_JOB_PRIORITY_URGENT; i < EV_JOB_N_PRIORITIES; i++) {
 		job = (EvSchedulerJob *) g_queue_pop_head (job_queue[i]);
 		if (job)
@@ -86,7 +86,7 @@ static gpointer
 ev_job_scheduler_init (gpointer data)
 {
 	g_thread_new ("EvJobScheduler", ev_job_thread_proxy, NULL);
-	
+
 	return NULL;
 }
 
@@ -94,12 +94,12 @@ static void
 ev_scheduler_job_list_add (EvSchedulerJob *job)
 {
 	ev_debug_message (DEBUG_JOBS, "%s", EV_GET_TYPE_NAME (job->job));
-	
+
 	G_LOCK (job_list);
 
 	job_list = g_slist_prepend (job_list, job);
 	job->job_link = job_list;
-	
+
 	G_UNLOCK (job_list);
 }
 
@@ -107,11 +107,11 @@ static void
 ev_scheduler_job_list_remove (EvSchedulerJob *job)
 {
 	ev_debug_message (DEBUG_JOBS, "%s", EV_GET_TYPE_NAME (job->job));
-	
+
 	G_LOCK (job_list);
 
 	job_list = g_slist_delete_link (job_list, job->job_link);
-	
+
 	G_UNLOCK (job_list);
 }
 
@@ -131,7 +131,7 @@ ev_scheduler_job_destroy (EvSchedulerJob *job)
 	ev_debug_message (DEBUG_JOBS, "%s", EV_GET_TYPE_NAME (job->job));
 
 	if (job->job->run_mode == EV_JOB_RUN_MAIN_LOOP) {
-		g_signal_handlers_disconnect_by_func (job->job, 
+		g_signal_handlers_disconnect_by_func (job->job,
 						      G_CALLBACK (ev_scheduler_job_destroy),
 						      job);
 	} else {
@@ -139,7 +139,7 @@ ev_scheduler_job_destroy (EvSchedulerJob *job)
 						      G_CALLBACK (ev_scheduler_thread_job_cancelled),
 						      job);
 	}
-	
+
 	ev_scheduler_job_list_remove (job);
 	ev_scheduler_job_free (job);
 }
@@ -149,7 +149,7 @@ ev_scheduler_thread_job_cancelled (EvSchedulerJob *job,
 				   GCancellable   *cancellable)
 {
 	GList   *list;
-	
+
 	ev_debug_message (DEBUG_JOBS, "%s", EV_GET_TYPE_NAME (job->job));
 
 	g_mutex_lock (&job_queue_mutex);
@@ -157,7 +157,7 @@ ev_scheduler_thread_job_cancelled (EvSchedulerJob *job,
 	/* If the job is not still running,
 	 * remove it from the job queue and job list.
 	 * If the job is currently running, it will be
-	 * destroyed as soon as it finishes. 
+	 * destroyed as soon as it finishes.
 	 */
 	list = g_queue_find (job_queue[job->priority], job);
 	if (list) {
@@ -213,7 +213,7 @@ ev_job_thread_proxy (gpointer data)
 			continue;
 		}
 		g_mutex_unlock (&job_queue_mutex);
-		
+
 		ev_job_thread (job->job);
 		ev_scheduler_job_destroy (job);
 	}
@@ -237,7 +237,7 @@ ev_job_scheduler_push_job (EvJob         *job,
 	s_job->priority = priority;
 
 	ev_scheduler_job_list_add (s_job);
-	
+
 	switch (ev_job_get_run_mode (job)) {
 	case EV_JOB_RUN_THREAD:
 		g_signal_connect_swapped (job->cancellable, "cancelled",
@@ -275,7 +275,7 @@ ev_job_scheduler_update_job (EvJob         *job,
 		return;
 
 	ev_debug_message (DEBUG_JOBS, "%s pirority %d", EV_GET_TYPE_NAME (job), priority);
-	
+
 	G_LOCK (job_list);
 
 	for (l = job_list; l; l = l->next) {
@@ -286,14 +286,14 @@ ev_job_scheduler_update_job (EvJob         *job,
 			break;
 		}
 	}
-	
+
 	G_UNLOCK (job_list);
 
 	if (need_resort) {
 		GList *list;
-	
+
 		g_mutex_lock (&job_queue_mutex);
-		
+
 		list = g_queue_find (job_queue[s_job->priority], s_job);
 		if (list) {
 			ev_debug_message (DEBUG_JOBS, "Moving job %s from pirority %d to %d",
@@ -302,7 +302,7 @@ ev_job_scheduler_update_job (EvJob         *job,
 			g_queue_push_tail (job_queue[priority], s_job);
 			g_cond_broadcast (&job_queue_cond);
 		}
-		
+
 		g_mutex_unlock (&job_queue_mutex);
 	}
 }

--- a/libview/ev-view-type-builtins.c.template
+++ b/libview/ev-view-type-builtins.c.template
@@ -15,7 +15,7 @@
 GType
 @enum_name@_get_type (void)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
+  static gsize g_define_type_id__volatile = 0;
  
   if (g_once_init_enter (&g_define_type_id__volatile)) {
     static const G@Type@Value values[] = {

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -4197,7 +4197,7 @@ ev_window_run_presentation (EvWindow *window)
             current_page,
             rotation,
             inverted_colors);
-    ev_view_presentation_set_rtl (window->priv->presentation_view, rtl);
+    ev_view_presentation_set_rtl (EV_VIEW_PRESENTATION (window->priv->presentation_view), rtl);
     g_signal_connect_swapped (window->priv->presentation_view, "finished",
             G_CALLBACK (ev_window_view_presentation_finished),
             window);
@@ -5259,7 +5259,7 @@ view_menu_link_popup (EvWindow *ev_window,
             switch (ev_link_action_get_action_type (ev_action)) {
             case EV_LINK_ACTION_TYPE_GOTO_DEST:
             case EV_LINK_ACTION_TYPE_GOTO_REMOTE:
-                //  2021-03-21 WHY WAS THIS BEING SET BUT NEVER USED? 
+                //  2021-03-21 WHY WAS THIS BEING SET BUT NEVER USED?
                 //show_internal = TRUE;
                 break;
             case EV_LINK_ACTION_TYPE_EXTERNAL_URI:
@@ -5623,7 +5623,7 @@ find_bar_visibility_changed_cb (EggFindBar *find_bar,
 
         if (visible)
             ev_window_search_start (ev_window);
-        else 
+        else
         {
             egg_find_bar_set_status_text (EGG_FIND_BAR (ev_window->priv->find_bar), NULL);
             egg_find_bar_set_search_string (EGG_FIND_BAR (ev_window->priv->find_bar), NULL);
@@ -6052,11 +6052,11 @@ ev_window_key_press_event (GtkWidget   *widget,
 
     if (window->priv->view != NULL) {
         /* Handle focus widget key events */
-        if (gtk_window_propagate_key_event (window, event))
+        if (gtk_window_propagate_key_event (GTK_WINDOW (window), event))
             return TRUE;
 
         // /* Handle mnemonics and accelerators */
-        if (gtk_window_activate_key (window, event))
+        if (gtk_window_activate_key (GTK_WINDOW (window), event))
             return TRUE;
     }
 


### PR DESCRIPTION
Fix build warnings:

* add missing type casts
* fix historical `volatile` artifacts
* migrate from deprecated `GdkColor` to `GdkRGBA`