### PR TITLE
Background colour of presentation view fixed.

### DIFF
--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -115,9 +115,6 @@ static void ev_view_presentation_set_cursor_for_location (EvViewPresentation *pv
 
 G_DEFINE_TYPE (EvViewPresentation, ev_view_presentation, GTK_TYPE_WIDGET)
 
-static GdkRGBA black = { 0., 0., 0., 1. };
-static GdkRGBA white = { 1., 1., 1., 1. };
-
 static void
 ev_view_presentation_set_normal (EvViewPresentation *pview)
 {
@@ -127,7 +124,7 @@ ev_view_presentation_set_normal (EvViewPresentation *pview)
 		return;
 
 	pview->state = EV_PRESENTATION_NORMAL;
-	gdk_window_set_background_rgba (gtk_widget_get_window (widget), &black);
+	gtk_style_context_remove_class (gtk_widget_get_style_context (widget), "white-mode");
 	gtk_widget_queue_draw (widget);
 }
 
@@ -140,7 +137,7 @@ ev_view_presentation_set_black (EvViewPresentation *pview)
 		return;
 
 	pview->state = EV_PRESENTATION_BLACK;
-	gdk_window_set_background_rgba (gtk_widget_get_window (widget), &black);
+	gtk_style_context_remove_class (gtk_widget_get_style_context (widget), "white-mode");
 	gtk_widget_queue_draw (widget);
 }
 
@@ -153,8 +150,7 @@ ev_view_presentation_set_white (EvViewPresentation *pview)
 		return;
 
 	pview->state = EV_PRESENTATION_WHITE;
-	gdk_window_set_background_rgba (gtk_widget_get_window (widget), &white);
-	gtk_widget_queue_draw (widget);
+	gtk_style_context_add_class (gtk_widget_get_style_context (widget), "white-mode");
 }
 
 static void
@@ -1025,6 +1021,13 @@ ev_view_presentation_draw (GtkWidget *widget,
 	cairo_surface_t    *surface;
 	cairo_rectangle_int_t clip_rect;
 	GdkRectangle *area = &clip_rect;
+	GtkStyleContext    *context;
+
+	context = gtk_widget_get_style_context (GTK_WIDGET (pview));
+	gtk_render_background (context, cr,
+	                       0, 0,
+	                       gtk_widget_get_allocated_width (widget),
+	                       gtk_widget_get_allocated_height (widget));
 
 	if (!gdk_cairo_get_clip_rectangle (cr, &clip_rect))
 		return FALSE;
@@ -1414,6 +1417,8 @@ ev_view_presentation_class_init (EvViewPresentationClass *klass)
 	widget_class->motion_notify_event = ev_view_presentation_motion_notify_event;
 	widget_class->scroll_event = ev_view_presentation_scroll_event;
 
+	gtk_widget_class_set_css_name (widget_class, "evpresentationview");
+
 	gobject_class->dispose = ev_view_presentation_dispose;
 
 	gobject_class->constructor = ev_view_presentation_constructor;
@@ -1516,25 +1521,8 @@ ev_view_presentation_class_init (EvViewPresentationClass *klass)
 static void
 ev_view_presentation_init (EvViewPresentation *pview)
 {
-	static gsize initialization_value = 0;
-
 	gtk_widget_set_can_focus (GTK_WIDGET (pview), TRUE);
-         pview->is_constructing = TRUE;
-
-	if (g_once_init_enter (&initialization_value)) {
-		GtkCssProvider *provider;
-
-		provider = gtk_css_provider_new ();
-		gtk_css_provider_load_from_data (provider,
-						 "EvViewPresentation {\n"
-						 " background-color: black; }",
-						 -1, NULL);
-		gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
-							   GTK_STYLE_PROVIDER (provider),
-							   GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-		g_object_unref (provider);
-		g_once_init_leave (&initialization_value, 1);
-	}
+	pview->is_constructing = TRUE;
 }
 
 GtkWidget *

--- a/shell/xreader.css
+++ b/shell/xreader.css
@@ -31,3 +31,18 @@ evview.document-page {
 evview.document-page.inverted {
     background-color: black;
 }
+
+#ev-loading-message {
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
+    border-radius: 3px;
+    padding: 8px;
+}
+
+evpresentationview {
+    background-color: black;
+}
+
+evpresentationview.white-mode {
+    background-color: white;
+}


### PR DESCRIPTION
Fixes https://github.com/linuxmint/xreader/issues/599. This is simply a port of https://github.com/mate-desktop/atril/commit/1d90b700c7bf5036e9f1e7ddd0adb09bd39467ce.

I don't fully understand why `gdk_window_set_background_rgba` stopped working, but with these changes, the 'b' and 'w' keyboard shortcuts appear to work! Also, the default background colour in presentation mode is black, so the text on the last screen is readable.