### PR TITLE
Djvu files: Fixed rotation direction 

### DIFF
--- a/backend/djvu/djvu-document.c
+++ b/backend/djvu/djvu-document.c
@@ -340,7 +340,7 @@ djvu_document_render (EvDocument      *document,
 	
 	switch (rc->rotation) {
 	        case 90:
-			rotation = DDJVU_ROTATE_90;
+			rotation = DDJVU_ROTATE_270;
 			tmp = page_height;
 			page_height = page_width;
 			page_width = tmp;
@@ -351,7 +351,7 @@ djvu_document_render (EvDocument      *document,
 			
 			break;
 	        case 270:
-			rotation = DDJVU_ROTATE_270;
+			rotation = DDJVU_ROTATE_90;
 			tmp = page_height;
 			page_height = page_width;
 			page_width = tmp;


### PR DESCRIPTION
Regarding the issue : https://github.com/linuxmint/xreader/issues/616

When opening Djvu files, and using the Rotate Left and Rotate Right options, xreader would rotate the document to the other direction. This may be due to a different convention of orientation used in the djvu backend.