### PR TITLE
Fix list of supported mime types

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,7 +112,7 @@ if get_option('comics')
         'application/x-ext-cbr',
         'application/x-ext-cbt',
         'application/x-ext-cbz',
-    ])
+    ]) + ';'
     xreader_mime_types += comic_mimetypes
 endif
 if get_option('xps')


### PR DESCRIPTION
There is a `;` missing when generating the list of supported mime types.

When doing an apt-get upgrade I got this message:

```
Error in file "/usr/share/applications/xreader.desktop": "application/x-ext-cbzapplication/oxps" is an invalid MIME type ("application/x-ext-cbzapplication/oxps" contains an invalid character in the subtype)
```

The proposed change is untested since I'm not familiar with the build process.