### PR TITLE
pdf backend: Ignore FullScreen PageMode catalog entry

### DIFF
--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -725,7 +725,9 @@ pdf_document_get_info (EvDocument *document)
 			info->mode = EV_DOCUMENT_MODE_USE_OC;
 			break;
 		case POPPLER_PAGE_MODE_FULL_SCREEN:
-			info->mode = EV_DOCUMENT_MODE_FULL_SCREEN;
+			// Ignore full screen page mode, since automatically opening
+			// in full screen mode is generally unwanted behavior
+			//info->mode = EV_DOCUMENT_MODE_FULL_SCREEN;
 			break;
 		case POPPLER_PAGE_MODE_USE_ATTACHMENTS:
 			info->mode = EV_DOCUMENT_MODE_USE_ATTACHMENTS;


### PR DESCRIPTION
Currently, Xreader will start in fullscreen if the `PageMode` entry in the PDF `catalog` dictionary is set to `FullScreen` (as far as I can tell, the PDF backend is the only backend that will do this). More often than I'd like, I end up downloading and trying to open PDFs where this property is set (it's seemingly randomly set on some academic journal articles) and find this behavior quite irritating. I can't think of a use case where this behavior would be desired. Thus, I'd advocate for removing it, which is what this pull request does, although adding a preference is also an option.

Poppler's [FullScreen.pdf](https://gitlab.freedesktop.org/poppler/test/-/blob/master/unittestcases/FullScreen.pdf) unit test case can be used to trigger this behavior.