### PR TITLE
epub: Fix an incorrect sizeof call detected by AddressSanitizer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ cd xreader
 # libraries, and shared files into /usr/local, and
 # enables all available options:
 
-meson buildir \
+meson builddir \
   --prefix=/usr/local \
   --buildtype=plain \
   -D deprecated_warnings=false \

--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1055,7 +1055,7 @@ setup_document_content_list(const gchar* content_uri, GError** error,gchar *docu
         }
         if ( xmlStrcmp(itemrefptr->name,(xmlChar*)"itemref") == 0)
         {
-            contentListNode *newnode = g_malloc0(sizeof(newnode));
+            contentListNode *newnode = g_malloc0(sizeof(*newnode));
             newnode->key = (gchar*)xml_get_data_from_node(itemrefptr,XML_ATTRIBUTE,(xmlChar*)"idref");
             if ( newnode->key == NULL )
             {


### PR DESCRIPTION
This commit also fixes a build directory typo in `INSTALL.md`.

### Testing
Prior to this fix, I would see memory errors when loading the EPUB from https://github.com/mate-desktop/atril/issues/599:

```
==131935==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000657b78 at pc 0x7fffd95aada0 bp 0x7fffda8dec00 sp 0x7fffda8debf0
WRITE of size 8 at 0x602000657b78 thread T43
    #0 0x7fffd95aad9f in setup_document_content_list ../backend/epub/epub-document.c:1091
    #1 0x7fffd95ae153 in epub_document_load ../backend/epub/epub-document.c:1801
    #2 0x7ffff7f33434 in ev_document_load ../libdocument/ev-document.c:251
    #3 0x7ffff7f3a1aa in ev_document_factory_get_document ../libdocument/ev-document-factory.c:237
    #4 0x7ffff775c264 in ev_job_load_run ../libview/ev-jobs.c:1124
    #5 0x7ffff77579b2 in ev_job_run ../libview/ev-jobs.c:219
    #6 0x7ffff775fd9e in ev_job_thread ../libview/ev-job-scheduler.c:184
    #7 0x7ffff775ff8c in ev_job_thread_proxy ../libview/ev-job-scheduler.c:217
    #8 0x7ffff7657a04  (/usr/lib/libglib-2.0.so.0+0x8ba04)
    #9 0x7ffff66839ea  (/usr/lib/libc.so.6+0x8c9ea)
    #10 0x7ffff67077cb  (/usr/lib/libc.so.6+0x1107cb)

0x602000657b78 is located 0 bytes after 8-byte region [0x602000657b70,0x602000657b78)
allocated by thread T43 here:
    #0 0x7ffff78e0cc1 in __interceptor_calloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7ffff76302ba in g_malloc0 (/usr/lib/libglib-2.0.so.0+0x642ba)
    #2 0x7fffd95ae153 in epub_document_load ../backend/epub/epub-document.c:1801
    #3 0x7ffff7f33434 in ev_document_load ../libdocument/ev-document.c:251
    #4 0x7ffff7f3a1aa in ev_document_factory_get_document ../libdocument/ev-document-factory.c:237
    #5 0x7ffff775c264 in ev_job_load_run ../libview/ev-jobs.c:1124
    #6 0x7ffff77579b2 in ev_job_run ../libview/ev-jobs.c:219
    #7 0x7ffff775fd9e in ev_job_thread ../libview/ev-job-scheduler.c:184
    #8 0x7ffff775ff8c in ev_job_thread_proxy ../libview/ev-job-scheduler.c:217
    #9 0x7ffff7657a04  (/usr/lib/libglib-2.0.so.0+0x8ba04)

Thread T43 created by T0 here:
    #0 0x7ffff784a497 in __interceptor_pthread_create /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:208
    #1 0x7ffff7658fb3  (/usr/lib/libglib-2.0.so.0+0x8cfb3)

SUMMARY: AddressSanitizer: heap-buffer-overflow ../backend/epub/epub-document.c:1091 in setup_document_content_list
```