### PR TITLE
Index collapsed by default

### DIFF
--- a/shell/ev-sidebar-links.c
+++ b/shell/ev-sidebar-links.c
@@ -626,6 +626,7 @@ job_finished_callback (EvJobLinks     *job,
 	priv->job = NULL;
 
 	expand_open_links (GTK_TREE_VIEW (priv->tree_view), priv->model, NULL);
+	gtk_tree_view_collapse_all (GTK_TREE_VIEW (priv->tree_view));
 
 	selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (priv->tree_view));
 	gtk_tree_selection_set_mode (selection, GTK_SELECTION_SINGLE);


### PR DESCRIPTION
This is a one-liner to make the sidebar index treeview collapsed by default, on behalf of myself and [this user](https://github.com/orgs/linuxmint/discussions/711).