### PR TITLE
epub: avoid a fixed-size buffer when copying the content path prefix

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -921,15 +921,8 @@ get_uri_to_content(const gchar* uri,GError ** error,EpubDocument *epub_document)
 
 	gchar* documentfolder = g_strrstr((gchar*)relativepath,"/");
 	if (documentfolder != NULL) {
-		gchar* copybuffer = (gchar*)relativepath ;
-		gchar* directorybuffer = g_malloc0(sizeof(gchar*)*100);
-		gchar* writer = directorybuffer;
-
-		while(copybuffer != documentfolder) {
-			(*writer) = (*copybuffer);
-			writer++;copybuffer++;
-		}
-		*writer = '\0';
+		gsize dir_len = documentfolder - (gchar *) relativepath;
+		gchar *directorybuffer = g_strndup ((gchar *) relativepath, dir_len);
 
 		GString *documentdir = g_string_new(tmp_archive_dir);
 		g_string_append_printf(documentdir,"/%s",directorybuffer);


### PR DESCRIPTION
Hi, and thanks for xreader.

I have been writing a markdown backend for xreader as a hobby, with help
from an AI coding assistant, which flagged this while I was in the EPUB
code. I reviewed it and think it is a small, worthwhile cleanup.

In `get_uri_to_content()` (`backend/epub/epub-document.c`), the directory
part of the OPF path is copied into a fixed buffer with a hand-written
loop that runs until the last `/`, with no bound on how much it copies:

```c
gchar* directorybuffer = g_malloc0(sizeof(gchar*)*100);
gchar* writer = directorybuffer;
while (copybuffer != documentfolder) {
        (*writer) = (*copybuffer);
        writer++; copybuffer++;
}
*writer = '\0';
```

The string being copied is `relativepath`, the `full-path` attribute read
from the EPUB's `META-INF/container.xml`, so its length is whatever the
file declares; nothing here bounds it.

Two things about the allocation also stand out:

- The element size is `sizeof(gchar*)`, the size of a *pointer* (8 bytes
  on 64-bit). But the buffer holds a string of `gchar`, i.e. characters,
  not pointers. The size that matches the data being copied is
  `sizeof(gchar)` (1 byte), or simply a byte count. So the `*` is the
  wrong type for what is actually stored, and the buffer ends up ~800
  bytes only by accident.
- `100` is a magic number: there is no explanation for why it is 100.

Because the copy loop is unbounded, the buffer's correctness rests on
those accidents. Normal EPUBs use short OPF paths, so this is not hit in
everyday use, but since the length comes from the file, a long enough
`full-path` would copy past the buffer. And if someone corrected the
obvious type mismatch, `sizeof(gchar*)` to `sizeof(gchar)`, the buffer
would shrink to 100 bytes and the same loop would write past the end on
ordinary paths.

The fix computes the length and uses `g_strndup()`:

```c
gsize dir_len = documentfolder - (gchar *) relativepath;
gchar *directorybuffer = g_strndup ((gchar *) relativepath, dir_len);
```

`g_strndup` allocates a buffer sized to the prefix length, so the copy
stays within bounds regardless of the input. It also removes the magic
number, the wrong-typed `sizeof`, and the hand-written loop, and produces
the same string as before.

Thanks for taking a look.
