### PR TITLE
epub: avoid a fixed-size buffer for the zip entry filename

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -41,6 +41,9 @@
 /*For strcasestr(),strstr()*/
 #include <string.h>
 
+/* For PATH_MAX */
+#include <limits.h>
+
 typedef enum _xmlParseReturnType
 {
     XML_ATTRIBUTE,
@@ -670,7 +673,6 @@ extract_one_file(EpubDocument* epub_document, GFile *tmp_gfile, GError ** error)
     GFile * outfile ;
     gsize writesize = 0;
     GString * gfilepath ;
-    unz_file_info64 info ;
     gchar* directory;
 	GString* dir_create;
     GFileOutputStream * outstream ;
@@ -682,8 +684,41 @@ extract_one_file(EpubDocument* epub_document, GFile *tmp_gfile, GError ** error)
 
     gboolean result = TRUE;
 
-    gpointer currentfilename = g_malloc0(512);
-    unzGetCurrentFileInfo64(epub_document->epubDocument,&info,currentfilename,512,NULL,0,NULL,0) ;
+	unz_file_info64 file_info;
+	int uret;
+
+	uret = unzGetCurrentFileInfo64 (epub_document->epubDocument,
+					&file_info, NULL, 0,
+					NULL, 0, NULL, 0);
+	if (uret != UNZ_OK) {
+		g_warning ("cannot read zip entry info");
+		unzCloseCurrentFile (epub_document->epubDocument);
+		return FALSE;
+	}
+
+	/* PATH_MAX comes from <limits.h>: the system's maximum path
+	 * length. The zip file-name-length field is a 16-bit value, so
+	 * it can reach 65535 bytes, far longer than any path this code
+	 * can usefully extract to. Reject such an entry rather than
+	 * allocate for and process it. */
+	if (file_info.size_filename > PATH_MAX) {
+		g_warning ("zip entry name too long (%lu bytes)",
+			   (unsigned long) file_info.size_filename);
+		unzCloseCurrentFile (epub_document->epubDocument);
+		return FALSE;
+	}
+
+	gpointer currentfilename = g_malloc0 (file_info.size_filename + 1);
+	uret = unzGetCurrentFileInfo64 (epub_document->epubDocument,
+					&file_info, currentfilename,
+					file_info.size_filename + 1,
+					NULL, 0, NULL, 0);
+	if (uret != UNZ_OK) {
+		g_free (currentfilename);
+		g_warning ("cannot read zip entry filename");
+		unzCloseCurrentFile (epub_document->epubDocument);
+		return FALSE;
+	}
     directory = g_strrstr(currentfilename,"/") ;
 
     if ( directory != NULL )


### PR DESCRIPTION
Hello,

This is in `extract_one_file()` in `backend/epub/epub-document.c`, which
extracts one entry of the EPUB's zip archive. The current entry's
filename is read into a fixed 512-byte buffer:

```c
gpointer currentfilename = g_malloc0(512);
unzGetCurrentFileInfo64(..., currentfilename, 512, ...);
```

The name comes from the zip archive: `unzGetCurrentFileInfo64()` reads
it from the current zip entry, and its length is the entry's
file-name-length field, a 16-bit value in the zip format. So the length
is whatever the file declares, nothing here bounds it, and that call's
return value is not checked. minizip copies at most the supplied buffer
size and only NUL-terminates the name when it fits within that size, so
a zip entry name of 512 bytes or more leaves `currentfilename`
truncated and without a terminator. The uses just below it
(`g_strrstr`, the `g_string_append_printf`, the `.html` check) then read
past the 512-byte allocation.

The change reads the real name length first, by calling
`unzGetCurrentFileInfo64()` once with a NULL name buffer to fill in
`file_info.size_filename`, then allocates `size_filename + 1` so the
terminator always fits, and checks the return code of both calls.

Because the zip file-name-length field is 16-bit, `size_filename` can be
as large as 65535, which is not a usable extraction path. The change
rejects an entry whose name is longer than `PATH_MAX` (from
`<limits.h>`, the system's maximum path length) before allocating, so
the allocation stays bounded to a sane path length and an absurd name is
stopped before it reaches the path-building code.

The new early-return paths close the entry that `unzOpenCurrentFile()`
opened. The function's normal cleanup runs only at the `out:` label, and
these returns happen before `gfilepath` is initialised, so they cannot
jump there (`g_string_free()` would read an indeterminate pointer); each
one closes the entry by hand and frees `currentfilename` only where it
has already been allocated. For an ordinary short name the result is the
same NUL-terminated string as before. The separate fixed 512-byte buffer
used to read the file contents further down is unrelated and left
unchanged.

Thanks for taking a look.
