### PR TITLE
epub: guard against a NULL head node in add_mathjax_script_node_to_file

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1700,7 +1700,7 @@ add_mathjax_script_node_to_file(gchar *filename, gchar *data)
 		head = head->next;
 	}
 
-	if (xmlStrcmp(head->name,(xmlChar*)"head")) {
+	if (head == NULL || xmlStrcmp(head->name,(xmlChar*)"head")) {
 		return ;
 	}
 


### PR DESCRIPTION
Hello,

When an EPUB content document is flagged for MathML (its OPF manifest
item carries properties="mathml"), the backend injects a MathJax script
element into that document's head so the math renders. That injection is
add_mathjax_script_node_to_file() in backend/epub/epub-document.c, which
finds the head by walking the children of the document root:

    xmlNodePtr head = mathroot->children;
    while(head != NULL) {
        if (!xmlStrcmp(head->name,(xmlChar*)"head")) {
            break;
        }
        head = head->next;
    }
    if (xmlStrcmp(head->name,(xmlChar*)"head")) {
        return ;
    }

If a head child is found, the loop breaks with head valid. If none is
found, or the root has no children, the loop exits with head == NULL,
and the next line reads head->name on that NULL pointer and crashes.

A normal XHTML page has a head, so this does not happen for well-formed
EPUBs. It is reachable on malformed or unusual input: the path of the
file injected into comes straight from the manifest href, and nothing
checks its structure before parsing. A content document whose root has
no head child (an html with only a body, a non-html root, or an empty
root) reaches the dereference. Since EPUB files are untrusted input,
this is a robustness fix rather than a fix for a crash on valid
documents.

The change adds a head == NULL guard before the dereference; the ||
short-circuits, so a NULL head returns cleanly and a non-NULL head is
unchanged.

I did consider going further and creating a head element when one is
missing, so the MathJax script could still be inserted and the math
would render. I decided against it. A normal EPUB already has a head, so
that case is rare, and doing it properly is noticeably more work (it is
only valid when the root is html, and the new head has to be placed as
the first child, before body). For almost no practical gain it would add
behaviour and complexity to a path that should simply decline to touch a
malformed document, which is what the function already does when the
root element is missing. So this change only prevents the crash.

Thanks for taking a look.
