### PR TITLE
epub: free the parsed document in its owning load functions, not in set_xml_root_node

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -487,7 +487,6 @@ set_xml_root_node(xmlChar* rootname)
 
 	if (xmlroot == NULL) {
 
-		xmlFreeDoc(xmldocument);
 		return FALSE;
 	}
 
@@ -896,6 +895,7 @@ get_uri_to_content(const gchar* uri,GError ** error,EpubDocument *epub_document)
                             EV_DOCUMENT_ERROR,
                             EV_DOCUMENT_ERROR_INVALID,
                             _("container file is corrupt"));
+        xml_free_doc();
         return NULL ;
     }
 
@@ -906,6 +906,7 @@ get_uri_to_content(const gchar* uri,GError ** error,EpubDocument *epub_document)
                             EV_DOCUMENT_ERROR,
                             EV_DOCUMENT_ERROR_INVALID,
                             _("epub file is invalid or corrupt"));
+        xml_free_doc();
         return NULL ;
     }
 
@@ -916,6 +917,7 @@ get_uri_to_content(const gchar* uri,GError ** error,EpubDocument *epub_document)
                             EV_DOCUMENT_ERROR,
                             EV_DOCUMENT_ERROR_INVALID,
                             _("epub file is corrupt, no container"));
+        xml_free_doc();
         return NULL ;
     }
 
@@ -958,6 +960,7 @@ get_uri_to_content(const gchar* uri,GError ** error,EpubDocument *epub_document)
                                  EV_DOCUMENT_ERROR_INVALID,
                                  _("could not retrieve container file"));
         }
+        xml_free_doc();
         return NULL ;
     }
 	xml_free_doc();
@@ -1010,6 +1013,7 @@ setup_document_content_list(const gchar* content_uri, GError** error,gchar *docu
                             EV_DOCUMENT_ERROR,
                             EV_DOCUMENT_ERROR_INVALID,
                             _("content file is invalid"));
+        xml_free_doc();
         return FALSE ;
     }
 
@@ -1019,6 +1023,7 @@ setup_document_content_list(const gchar* content_uri, GError** error,gchar *docu
                             EV_DOCUMENT_ERROR,
                             EV_DOCUMENT_ERROR_INVALID,
                             _("epub file has no spine"));
+        xml_free_doc();
         return FALSE ;
     }
 
@@ -1028,6 +1033,7 @@ setup_document_content_list(const gchar* content_uri, GError** error,gchar *docu
                             EV_DOCUMENT_ERROR,
                             EV_DOCUMENT_ERROR_INVALID,
                             _("epub file has no manifest"));
+        xml_free_doc();
         return FALSE ;
     }
 
@@ -1122,6 +1128,7 @@ setup_document_content_list(const gchar* content_uri, GError** error,gchar *docu
         }
         /*free any nodes that were set up and return empty*/
         g_list_free_full(newlist, (GDestroyNotify)free_tree_nodes);
+        xml_free_doc();
         return NULL;
     }
 
@@ -1169,6 +1176,7 @@ get_toc_file_name(gchar *containeruri)
 
     /*In an epub3, there is sometimes no toc, and we need to then use the nav file for this.*/
     if (ncx == NULL) {
+        xml_free_doc();
         return NULL;
     }
 
@@ -1556,7 +1564,9 @@ epub_document_get_alternate_stylesheet(gchar *docuri)
     xml_parse_children_of_node(head,(xmlChar*)"link",(xmlChar*)"class",(xmlChar*)"night");
 
     if (xmlretval != NULL) {
-        return (gchar*)xml_get_data_from_node(xmlretval,XML_ATTRIBUTE,(xmlChar*)"href");
+        gchar *stylesheet = (gchar*)xml_get_data_from_node(xmlretval,XML_ATTRIBUTE,(xmlChar*)"href");
+        xml_free_doc();
+        return stylesheet;
     }
     xml_free_doc();
     return NULL;


### PR DESCRIPTION
Hello,

This moves ownership of the parsed XML document in the EPUB backend to
the functions that open it, and frees it on the load-path returns that
currently leave it allocated.

Background: backend/epub/epub-document.c parses container.xml, the OPF
package document and the per-page XHTML into a single file-scope global,
xmldocument, and releases it with the helper xml_free_doc(), which frees
the document and sets the global back to NULL. open_xml_document() just
assigns xmldocument = xmlParseFile(...) without freeing any previous
value, and a load opens these documents in series, so a tree left
unreleased is lost when the next open overwrites the pointer (it is not
freed at finalize either). The values these functions return (a content
URI, the content list, a toc file name, a stylesheet href) are
independent allocations, so each opener can free the document before
returning.

set_xml_root_node() used to free the global on its no-root-element branch
with a bare xmlFreeDoc(). I have removed that: it now only validates the
root element and frees nothing. Freeing inside it is not safe anyway,
because two callers pass a non-NULL root name and ignore the return value
(setup_document_index with "ncx", epub_document_get_info with "package")
and then call xml_get_pointer_to_node(), which dereferences the root
node; a free inside the helper on a root-name mismatch would leave them
using freed memory. Leaving the release to the openers also keeps the
failure mode benign: a caller that omits a free leaks rather than uses
freed memory.

With the helper no longer freeing, the openers free on the returns that
previously leaked:

  - get_uri_to_content(): the "container file is corrupt" return (the
    set_xml_root_node failure), plus "invalid or corrupt" (no rootfile
    node), "no container" (no full-path attribute) and "could not
    retrieve container file" (g_filename_to_uri failed).
  - setup_document_content_list(): the "content file is invalid" return,
    plus "no spine", "no manifest" and the errorflag return.
  - get_toc_file_name(): the early return when the spine has no "toc"
    attribute. Per the in-code comment this is the EPUB3 case with no
    NCX, where the nav file is used instead, so it is reached for ordinary
    EPUB3 documents, not only malformed input.
  - epub_document_get_alternate_stylesheet(): the success path, when a
    night-mode <link class="night"> is present. The href is an xmlGetProp
    copy independent of the document, so the document is freed first and
    the copy returned afterwards.

setup_document_index and epub_document_get_info already call
xml_free_doc() at their natural ends and have no early return after
opening the document, so they need no change.

xml_free_doc() sets the global to NULL after freeing, so the added calls
are fine on every path; successful return values are unchanged (the same
strings and lists), and only the point at which the parsed tree is
released changes.

Best regards,
Max
