### PR TITLE
epub: free the ncx toc attribute string in get_toc_file_name

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1174,6 +1174,7 @@ get_toc_file_name(gchar *containeruri)
 
 	xmlretval = NULL;
 	xml_parse_children_of_node(manifest,(xmlChar*)"item",(xmlChar*)"id",ncx);
+	xmlFree(ncx);
 
 	gchar* tocfilename = (gchar*)xml_get_data_from_node(xmlretval,XML_ATTRIBUTE,(xmlChar*)"href");
 	xml_free_doc();


### PR DESCRIPTION
Hello,

This frees a small string that get_toc_file_name() in the EPUB backend
leaks on its success path.

get_toc_file_name() reads the spine's "toc" attribute with
xml_get_data_from_node(spine, XML_ATTRIBUTE, ...), which calls
xmlGetProp() and returns a freshly allocated copy that the caller must
release with xmlFree(). The value (ncx) is used once, to match the
manifest item id, and is then never freed: the success path returns the
toc file name without releasing ncx. (On the ncx == NULL path no ncx
string was allocated.) get_toc_file_name() runs once per load from
setup_document_index() for documents that carry an NCX toc, so the leak
happens on ordinary loads of such documents.

Free ncx with xmlFree() right after its last use. xmlFree() matches the
xmlGetProp() allocation.

Best regards,
Max
