### PR TITLE
dvi-document: Use g_spawn_sync with argv instead of cmdline string

### DIFF
--- a/backend/dvi/dvi-document.c
+++ b/backend/dvi/dvi-document.c
@@ -368,27 +368,41 @@ dvi_document_file_exporter_do_page (EvFileExporter  *exporter,
 static void
 dvi_document_file_exporter_end (EvFileExporter *exporter)
 {
-	gchar *command_line;
 	gint exit_stat;
 	GError *err = NULL;
 	gboolean success;
-	
+	gchar *pages;
+	gsize  pages_len;
+
 	DviDocument *dvi_document = DVI_DOCUMENT(exporter);
-	gchar* quoted_filename = g_shell_quote (dvi_document->context->filename);
-	
-	command_line = g_strdup_printf ("dvipdfm %s -o %s %s", /* dvipdfm -s 1,2,.., -o exporter_filename dvi_filename */
-					dvi_document->exporter_opts->str,
-					dvi_document->exporter_filename,
-					quoted_filename);
-	g_free (quoted_filename);
 
-	success = g_spawn_command_line_sync (command_line,
-					     NULL,
-					     NULL,
-					     &exit_stat,
-					     &err);
+	/* exporter_opts is built as "-s 1,2,3,...".  For an argv[] spawn we
+	 * need to split it into two separate arguments and strip the trailing
+	 * comma that do_page() appends after every page index.  Using
+	 * g_spawn_sync() with an explicit argv[] array (rather than building a
+	 * command-line string and going through g_spawn_command_line_sync())
+	 * removes the shell-tokenizer from the trust boundary: each element is
+	 * passed verbatim to dvipdfm.
+	 */
+	pages = g_strdup (dvi_document->exporter_opts->str + strlen ("-s "));
+	pages_len = strlen (pages);
+	if (pages_len > 0 && pages[pages_len - 1] == ',')
+		pages[pages_len - 1] = '\0';
 
-	g_free (command_line);
+	gchar *argv[] = {
+		(gchar *) "dvipdfm",
+		(gchar *) "-s",
+		pages,
+		(gchar *) "-o",
+		dvi_document->exporter_filename,
+		dvi_document->context->filename,
+		NULL
+	};
+
+	success = g_spawn_sync (NULL, argv, NULL, 0, NULL, NULL,
+	                        NULL, &exit_stat, &err);
+
+	g_free (pages);
 
 	if (success == FALSE) {
 		g_warning ("Error: %s", err->message);


### PR DESCRIPTION
## Summary

When exporting a DVI document to PDF, the DVI backend ran `dvipdfm` through `g_spawn_command_line_sync()`, which routes the command string through `/bin/sh -c`. The argument values came from three places:

* `exporter_opts->str`: built from page indices, low risk in practice
* `exporter_filename`: chosen by the user in the export file dialog
* `context->filename`: the path of the opened DVI document

While the user-supplied values were shell-quoted with `g_shell_quote()`, this is the same fragile pattern that was recently patched in `ev_spawn` (commit 50052ea) and that the print previewer path also used. Build the `argv[]` array directly instead.

## What changes

* `g_spawn_command_line_sync(command_line)` -> `g_spawn_sync(NULL, argv, NULL, 0, ...)`
* The `-s <pages>` pair is split from `exporter_opts` and the trailing comma appended by `do_page()` is stripped, so `dvipdfm` receives the pages list as a single argument exactly as it would have through the shell
* No shell, no tokenizer on our side: each element is forwarded verbatim to the child

## Behavior preserved

* Same child process (`dvipdfm`)
* Same effective argv (verified by walking through the original `g_shell_quote()` output of each arg)
* Same exit-status reporting to the caller (the `WIFEXITED` / `WEXITSTATUS` checks still work)

## Why this matters

The `ev_spawn` fix in 50052ea (May 2026) only added `g_shell_quote()` to the page label / named destination / search string arguments. That is defense-in-depth for one specific call site. This DVI path was missed -- it never had `g_shell_quote()` applied to `exporter_opts` or `exporter_filename`, so a DVI document that lives at a path containing shell metacharacters (or a user who picks an output path with `$(...)` in it) would have those characters interpreted by `/bin/sh` today.

## Test plan

* `meson setup build && meson compile -C build` -- clean build
* Manual: open a `.dvi` file, **File -> Export To -> PDF**, choose a path with spaces and special chars in it -- export succeeds, output PDF is correct
* Manual: confirm that `dvipdfm` receives `-s` and the comma-separated page list as separate args (run with `strace -f -e execve` if needed)

## Diff stat

```
 backend/dvi/dvi-document.c | 48 ++++++++++++++++++++++++++++++----------------
 1 file changed, 31 insertions(+), 17 deletions(-)
```