### PR TITLE
Fix Ctrl+L page selector focus in fullscreen

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -615,8 +615,9 @@ update_chrome_visibility (EvWindow *window)
     fullscreen_mode = fullscreen || presentation;
 
     menubar = (priv->chrome & EV_CHROME_MENUBAR) != 0 && !fullscreen_mode;
-    toolbar = ((priv->chrome & EV_CHROME_TOOLBAR) != 0  ||
-                  (priv->chrome & EV_CHROME_RAISE_TOOLBAR) != 0) && !presentation && !fullscreen;
+    toolbar = !presentation && (fullscreen
+        ? (priv->chrome & (EV_CHROME_RAISE_TOOLBAR | EV_CHROME_FULLSCREEN_TOOLBAR)) != 0
+        : (priv->chrome & (EV_CHROME_TOOLBAR | EV_CHROME_RAISE_TOOLBAR)) != 0);
     fullscreen_toolbar = ((priv->chrome & EV_CHROME_FULLSCREEN_TOOLBAR) != 0 ||
                             (priv->chrome & EV_CHROME_RAISE_TOOLBAR) != 0) && fullscreen;
     findbar = (priv->chrome & EV_CHROME_FINDBAR) != 0;
@@ -3786,6 +3787,25 @@ ev_window_cmd_file_close_all_windows (GtkAction *action,
 }
 
 static void
+focus_page_selector_revealed_cb (GtkRevealer *revealer,
+                                 GParamSpec  *pspec,
+                                 EvWindow    *window)
+{
+    GtkAction *action;
+
+    if (!gtk_revealer_get_child_revealed (revealer))
+        return;
+
+    action = gtk_action_group_get_action (window->priv->action_group,
+            PAGE_SELECTOR_ACTION);
+    ev_page_action_grab_focus (EV_PAGE_ACTION (action));
+
+    g_signal_handlers_disconnect_by_func (revealer,
+                                          focus_page_selector_revealed_cb,
+                                          window);
+}
+
+static void
 ev_window_cmd_focus_page_selector (GtkAction *act,
                                    EvWindow  *window)
 {
@@ -3797,7 +3817,11 @@ ev_window_cmd_focus_page_selector (GtkAction *act,
 
     action = gtk_action_group_get_action (window->priv->action_group,
             PAGE_SELECTOR_ACTION);
-    ev_page_action_grab_focus (EV_PAGE_ACTION (action));
+    if (gtk_revealer_get_child_revealed (GTK_REVEALER (window->priv->toolbar_revealer)))
+        ev_page_action_grab_focus (EV_PAGE_ACTION (action));
+    else
+        g_signal_connect (window->priv->toolbar_revealer, "notify::child-revealed",
+                          G_CALLBACK (focus_page_selector_revealed_cb), window);
 }
 
 static void


### PR DESCRIPTION
When in fullscreen, Ctrl+L never focuses the page selector toolbar entry, so the typed page number is ignored and pressing Enter advances to the next page.

In fullscreen the toolbar reveal expression was gated with `&& !fullscreen`, so the revealer never opened and the unmapped page entry could not receive focus. The reveal now opens in fullscreen when the toolbar is raised, and the focus grab is deferred until the revealer has shown the child so it lands after the 175ms slide-in transition.

Fixes #668

ps - Am a first time open-source contributor! Apologies if this is not the proper workflow :)